### PR TITLE
ci: add read-only permissions to Lint and Test workflows

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,6 +3,9 @@ name: Lint
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Run Linter

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,6 +3,9 @@ name: Run tests and upload coverage
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run tests and collect coverage


### PR DESCRIPTION
Update the Lint and Run tests workflows to explicitly set permissions to contents: read, ensuring they operate with least privilege. This restricts access to only reading repository contents, aligning with their read-only operations (checkout, linting, testing, and coverage upload) and enhancing security by avoiding unintended privileges.

- Add `permissions: contents: read` to Lint workflow.
- Add `permissions: contents: read` to Test workflow with Codecov upload.