### PR TITLE
Fix Lark doc generation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@29694d72cd5e7ef3b09496b39f28a942af47737e
         with:
-          go-version: 1.24.3
+          go-version: 1.24.x
 
       - name: Login to Docker Hub
         uses: docker/login-action@6d4b68b490aef8836e8fb5e50ee7b3bdfa5894f0

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,6 +7,9 @@ permissions:
   contents: write
   actions: read
 
+env:
+  GO_VERSION: 1.24.x
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -22,7 +25,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@29694d72cd5e7ef3b09496b39f28a942af47737e
         with:
-          go-version: "1.24"
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Generate Service Config Docs
         run: |

--- a/docs/generators/basic.md
+++ b/docs/generators/basic.md
@@ -3,9 +3,11 @@
 The basic generator looks at the `key:""`, `desc:""` and `default:""` tags on service configuration structs and uses them to ask the user to fill in their corresponding values.
 
 Example:
-```shell
-$ shoutrrr generate telegram
+
+```bash
+shoutrrr generate telegram
 ```
+
 ```yaml
 Generating URL for telegram using basic generator
 Enter the configuration values as prompted

--- a/docs/generators/overview.md
+++ b/docs/generators/overview.md
@@ -1,10 +1,10 @@
 # Generators
 
-Generators are used to create service configurations via the command line.  
+Generators are used to create service configurations via the command line.
 The main generator is the reflection based [Basic generator](./basic) that aims to be able to generator configurations for all the core services via a set of simple questions.
 
 ## Usage
 
 ```bash
-$ shoutrrr generate [OPTIONS] -g <GENERATOR> <SERVICE>
+shoutrrr generate [OPTIONS] -g <GENERATOR> <SERVICE>
 ```

--- a/pkg/services/lark/lark_config.go
+++ b/pkg/services/lark/lark_config.go
@@ -55,15 +55,18 @@ func (config *Config) SetURL(url *url.URL) error {
 // It sets the host, path, and query parameters, validating host and path, and returns an error if parsing or validation fails.
 func (config *Config) setURL(resolver types.ConfigQueryResolver, url *url.URL) error {
 	config.Host = url.Host
-	// Use default host if none provided (e.g., during documentation generation)
-	if config.Host == "" {
+	// Handle documentation generation or empty host
+	if config.Host == "" || (url.User != nil && url.User.Username() == "dummy") {
 		config.Host = "open.larksuite.com"
 	} else if config.Host != larkHost && config.Host != feishuHost {
 		return ErrInvalidHost
 	}
 
 	config.Path = strings.Trim(url.Path, "/")
-	if config.Path == "" {
+	// Handle documentation generation with empty path
+	if config.Path == "" && (url.User != nil && url.User.Username() == "dummy") {
+		config.Path = "token"
+	} else if config.Path == "" {
 		return ErrNoPath
 	}
 

--- a/pkg/services/lark/lark_config.go
+++ b/pkg/services/lark/lark_config.go
@@ -55,7 +55,10 @@ func (config *Config) SetURL(url *url.URL) error {
 // It sets the host, path, and query parameters, validating host and path, and returns an error if parsing or validation fails.
 func (config *Config) setURL(resolver types.ConfigQueryResolver, url *url.URL) error {
 	config.Host = url.Host
-	if config.Host != larkHost && config.Host != feishuHost {
+	// Use default host if none provided (e.g., during documentation generation)
+	if config.Host == "" {
+		config.Host = "open.larksuite.com"
+	} else if config.Host != larkHost && config.Host != feishuHost {
 		return ErrInvalidHost
 	}
 

--- a/pkg/services/lark/lark_service.go
+++ b/pkg/services/lark/lark_service.go
@@ -50,7 +50,7 @@ var httpClient = &http.Client{Timeout: defaultTime}
 // Service sends notifications to Lark.
 type Service struct {
 	standard.Standard
-	config *Config
+	Config *Config
 	pkr    format.PropKeyResolver
 }
 
@@ -60,7 +60,7 @@ func (service *Service) Send(message string, params *types.Params) error {
 		return ErrLargeMessage
 	}
 
-	config := *service.config
+	config := *service.Config
 	if err := service.pkr.UpdateConfigFromParams(&config, params); err != nil {
 		return fmt.Errorf("updating params: %w", err)
 	}
@@ -79,10 +79,10 @@ func (service *Service) Send(message string, params *types.Params) error {
 // Initialize configures the service with a URL and logger.
 func (service *Service) Initialize(configURL *url.URL, logger types.StdLogger) error {
 	service.SetLogger(logger)
-	service.config = &Config{}
-	service.pkr = format.NewPropKeyResolver(service.config)
+	service.Config = &Config{}
+	service.pkr = format.NewPropKeyResolver(service.Config)
 
-	return service.config.SetURL(configURL)
+	return service.Config.SetURL(configURL)
 }
 
 // GetID returns the service identifier.
@@ -174,8 +174,8 @@ func (service *Service) handleResponse(resp *http.Response) error {
 
 	service.Logf(
 		"Notification sent successfully to %s/%s",
-		service.config.Host,
-		service.config.Path,
+		service.Config.Host,
+		service.Config.Path,
 	)
 
 	return nil

--- a/pkg/services/lark/lark_test.go
+++ b/pkg/services/lark/lark_test.go
@@ -88,14 +88,14 @@ var _ = ginkgo.Describe("Lark Test", func() {
 					data[i] = "0123456789"
 				}
 				message := strings.Join(data, "")
-				service := Service{config: &Config{Host: larkHost, Path: "token"}}
+				service := Service{Config: &Config{Host: larkHost, Path: "token"}}
 				gomega.Expect(service.Send(message, nil)).To(gomega.MatchError(ErrLargeMessage))
 			})
 		})
 
 		ginkgo.When("an invalid param is passed", func() {
 			ginkgo.It("should fail to send messages", func() {
-				service := Service{config: &Config{Host: larkHost, Path: "token"}}
+				service := Service{Config: &Config{Host: larkHost, Path: "token"}}
 				gomega.Expect(
 					service.Send("test message", &types.Params{"invalid": "value"}),
 				).To(gomega.MatchError(gomega.ContainSubstring("not a valid config key: invalid")))

--- a/shoutrrr/cmd/docs/docs.go
+++ b/shoutrrr/cmd/docs/docs.go
@@ -75,7 +75,9 @@ func printDocs(docFormat string, services []string) cmd.Result {
 		// Initialize the service to populate Config
 		dummyURL, _ := url.Parse(scheme + "://dummy@dummy.com")
 		if err := service.Initialize(dummyURL, logger); err != nil {
-			return cmd.InvalidUsage(fmt.Sprintf("failed to initialize service %q: %v", scheme, err))
+			return cmd.InvalidUsage(
+				fmt.Sprintf("failed to initialize service %q: %v\n", scheme, err),
+			)
 		}
 
 		config := format.GetServiceConfig(service)


### PR DESCRIPTION
Fixes `lark` service doc generation issues.

- Renamed `config` to `Config` in `lark_service.go`.
- Updated `setURL` to handle dummy URLs.
- Verified doc generation (`go run .\shoutrrr docs -f markdown lark`) and tests (`go test -v`).