### PR TITLE
fix(meta): improve shoutrrr handling of dynamic metadata

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,9 @@
 #!/bin/sh
 
-go build -o shoutrrr/ ./shoutrrr
+# Get Git information
+VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "unknown")
+COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+DATE=$(git log -1 --format=%cd --date=iso | date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "unknown")
+
+# Build with ldflags
+go build -ldflags "-s -w -X github.com/nicholas-fedor/shoutrrr/internal/meta.Version=$VERSION -X github.com/nicholas-fedor/shoutrrr/internal/meta.Commit=$COMMIT -X github.com/nicholas-fedor/shoutrrr/internal/meta.Date=$DATE" -o shoutrrr ./shoutrrr

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -14,7 +14,7 @@ builds:
     ldflags:
       - -s -w
       - -X github.com/nicholas-fedor/shoutrrr/internal/meta.Version={{ .Version }}
-      - -X github.com/nicholas-fedor/shoutrrr/internal/meta.Commit={{.Commit}}
+      - -X github.com/nicholas-fedor/shoutrrr/internal/meta.Commit={{.ShortCommit}}
       - -X github.com/nicholas-fedor/shoutrrr/internal/meta.Date={{.Date}}
 
 archives:

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -12,7 +12,10 @@ builds:
       - arm
       - arm64
     ldflags:
-      - -s -w -X github.com/nicholas-fedor/shoutrrr/internal/meta.Version={{ .Version }}
+      - -s -w
+      - -X github.com/nicholas-fedor/shoutrrr/internal/meta.Version={{ .Version }}
+      - -X github.com/nicholas-fedor/shoutrrr/internal/meta.Commit={{.Commit}}
+      - -X github.com/nicholas-fedor/shoutrrr/internal/meta.Date={{.Date}}
 
 archives:
   - id: default # Unique ID for this archive configuration

--- a/internal/meta/doc.go
+++ b/internal/meta/doc.go
@@ -1,0 +1,3 @@
+// Package meta provides functionality to parse and manage metadata information
+// for Shoutrrr using Go's debug.ReadBuildInfo and GoReleaser build flags.
+package meta

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -76,6 +76,7 @@ func GetCommit() string {
 			for _, setting := range info.Settings {
 				if setting.Key == "vcs.revision" {
 					commit = setting.Value
+
 					break
 				}
 			}
@@ -144,5 +145,6 @@ func contains(s, substr string) bool {
 			return true
 		}
 	}
+
 	return false
 }

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -1,0 +1,148 @@
+package meta
+
+import (
+	"runtime/debug"
+	"time"
+)
+
+// Constants for repeated string values.
+const (
+	devVersion   = "dev"
+	unknownValue = "unknown"
+	trueValue    = "true"
+)
+
+// These values are populated by GoReleaser during release builds.
+var (
+	// Version is the Shoutrrr version (e.g., "v0.0.1").
+	Version = devVersion
+	// Commit is the Git commit SHA (e.g., "abc123").
+	Commit = unknownValue
+	// Date is the build or commit timestamp in RFC3339 format (e.g., "2025-05-07T00:00:00Z").
+	Date = unknownValue
+)
+
+// Info holds version information for Shoutrrr.
+type Info struct {
+	Version string
+	Commit  string
+	Date    string
+}
+
+// GetVersion returns the version string, using debug.ReadBuildInfo for source builds
+// or GoReleaser variables for release builds.
+func GetVersion() string {
+	version := Version
+
+	// If building from source (not GoReleaser), try to get version from debug.ReadBuildInfo
+	if version == devVersion || version == "" {
+		if info, ok := debug.ReadBuildInfo(); ok {
+			// Get the module version (e.g., v1.1.4 or v1.1.4+dirty)
+			version = info.Main.Version
+			if version == "(devel)" || version == "" {
+				version = devVersion
+			}
+			// Check for dirty state
+			for _, setting := range info.Settings {
+				if setting.Key == "vcs.modified" && setting.Value == trueValue &&
+					version != unknownValue && !contains(version, "+dirty") {
+					version += "+dirty"
+				}
+			}
+		}
+	} else {
+		// GoReleaser provides a valid version without 'v' prefix, so add it
+		if version != "" && version != "v" {
+			version = "v" + version
+		}
+	}
+
+	// Fallback default if still unset or invalid
+	if version == "" || version == devVersion || version == "v" {
+		return unknownValue
+	}
+
+	return version
+}
+
+// GetCommit returns the commit SHA, using debug.ReadBuildInfo for source builds
+// or GoReleaser variables for release builds.
+func GetCommit() string {
+	commit := Commit
+
+	// If building from source (not GoReleaser), try to get commit from debug.ReadBuildInfo
+	if commit == unknownValue || commit == "" {
+		if info, ok := debug.ReadBuildInfo(); ok {
+			for _, setting := range info.Settings {
+				if setting.Key == "vcs.revision" {
+					commit = setting.Value
+					break
+				}
+			}
+		}
+	}
+
+	// Shorten commit to 7 characters if it's a valid SHA
+	if len(commit) >= 7 && commit != unknownValue {
+		return commit[:7]
+	}
+
+	// Fallback default if still unset
+	if commit == "" {
+		return unknownValue
+	}
+
+	return commit
+}
+
+// GetDate returns the build or commit date, using debug.ReadBuildInfo for source builds
+// or GoReleaser variables for release builds.
+func GetDate() string {
+	date := Date
+
+	// If building from source (not GoReleaser), try to get date from debug.ReadBuildInfo
+	if date == unknownValue || date == "" {
+		if info, ok := debug.ReadBuildInfo(); ok {
+			for _, setting := range info.Settings {
+				if setting.Key == "vcs.time" {
+					if t, err := time.Parse(time.RFC3339, setting.Value); err == nil {
+						return t.Format("2006-01-02") // Shorten to YYYY-MM-DD
+					}
+				}
+			}
+		}
+	} else {
+		// Shorten date if provided by GoReleaser
+		if date != "" && date != unknownValue {
+			if t, err := time.Parse(time.RFC3339, date); err == nil {
+				return t.Format("2006-01-02") // Shorten to YYYY-MM-DD
+			}
+		}
+	}
+
+	// Fallback default if still unset
+	if date == "" {
+		return unknownValue
+	}
+
+	return date
+}
+
+// GetMetaInfo returns version information by combining GetVersion, GetCommit, and GetDate.
+func GetMetaInfo() Info {
+	return Info{
+		Version: GetVersion(),
+		Commit:  GetCommit(),
+		Date:    GetDate(),
+	}
+}
+
+// contains checks if a string contains a substring.
+func contains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/meta/meta_test.go
+++ b/internal/meta/meta_test.go
@@ -1,0 +1,228 @@
+package meta
+
+import (
+	"runtime/debug"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGetVersionInfo(t *testing.T) {
+	tests := []struct {
+		name         string
+		setVars      func()
+		expect       Info
+		partialMatch bool
+	}{
+		{
+			name: "GoReleaser build",
+			setVars: func() {
+				Version = "0.0.1"
+				Commit = "abc123456789"
+				Date = "2025-05-07T00:00:00Z"
+			},
+			expect: Info{
+				Version: "v0.0.1",
+				Commit:  "abc1234",
+				Date:    "2025-05-07",
+			},
+		},
+		{
+			name: "Source build with default values",
+			setVars: func() {
+				Version = devVersion
+				Commit = unknownValue
+				Date = unknownValue
+			},
+			expect: Info{
+				Version: unknownValue,
+				Commit:  unknownValue,
+				Date:    unknownValue,
+			},
+			partialMatch: true,
+		},
+		{
+			name: "Source build with empty values",
+			setVars: func() {
+				Version = ""
+				Commit = ""
+				Date = ""
+			},
+			expect: Info{
+				Version: unknownValue,
+				Commit:  unknownValue,
+				Date:    unknownValue,
+			},
+		},
+		{
+			name: "Invalid GoReleaser version",
+			setVars: func() {
+				Version = "v"
+				Commit = ""
+				Date = ""
+			},
+			expect: Info{
+				Version: unknownValue,
+				Commit:  unknownValue,
+				Date:    unknownValue,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setVars()
+
+			info := GetMetaInfo()
+
+			if !tt.partialMatch {
+				if info.Version != tt.expect.Version {
+					t.Errorf("Version = %q, want %q", info.Version, tt.expect.Version)
+				}
+
+				if info.Commit != tt.expect.Commit {
+					t.Errorf("Commit = %q, want %q", info.Commit, tt.expect.Commit)
+				}
+
+				if info.Date != tt.expect.Date {
+					t.Errorf("Date = %q, want %q", info.Date, tt.expect.Date)
+				}
+			} else if info.Version != tt.expect.Version && !strings.Contains(info.Version, "+dirty") {
+				t.Errorf("Version = %q, want %q or dirty variant", info.Version, tt.expect.Version)
+			}
+		})
+	}
+}
+
+func TestGetVersionInfo_VCSData(t *testing.T) {
+	Version = devVersion
+	Commit = unknownValue
+	Date = unknownValue
+
+	info := GetMetaInfo()
+
+	if buildInfo, ok := debug.ReadBuildInfo(); ok {
+		var vcsRevision, vcsTime, vcsModified string
+
+		for _, setting := range buildInfo.Settings {
+			switch setting.Key {
+			case "vcs.revision":
+				vcsRevision = setting.Value
+			case "vcs.time":
+				vcsTime = setting.Value
+			case "vcs.modified":
+				vcsModified = setting.Value
+			}
+		}
+
+		if vcsRevision != "" {
+			expectedCommit := vcsRevision
+			if len(vcsRevision) >= 7 {
+				expectedCommit = vcsRevision[:7]
+			}
+
+			if info.Commit == unknownValue {
+				t.Errorf(
+					"Expected commit %q, got %q; ensure repository has commit history",
+					expectedCommit,
+					info.Commit,
+				)
+			} else if info.Commit != expectedCommit {
+				t.Errorf("Commit = %q, want %q", info.Commit, expectedCommit)
+			}
+		} else {
+			t.Logf("No vcs.revision found; ensure repository has Git metadata to cover commit assignment")
+		}
+
+		if vcsTime != "" {
+			if parsedTime, err := time.Parse(time.RFC3339, vcsTime); err == nil {
+				expectedDate := parsedTime.Format("2006-01-02")
+				if info.Date == unknownValue {
+					t.Errorf(
+						"Expected date %q, got %q; ensure vcs.time is a valid RFC3339 timestamp",
+						expectedDate,
+						info.Date,
+					)
+				} else if info.Date != expectedDate {
+					t.Errorf("Date = %q, want %q", info.Date, expectedDate)
+				}
+			} else {
+				t.Logf("vcs.time %q is invalid; date should remain %q", vcsTime, unknownValue)
+
+				if info.Date != unknownValue {
+					t.Errorf("Expected date %q, got %q for invalid vcs.time", unknownValue, info.Date)
+				}
+			}
+		} else {
+			t.Logf("No vcs.time found; ensure repository has commit timestamps to cover date assignment")
+		}
+
+		if vcsModified == trueValue && info.Version != unknownValue {
+			if !strings.Contains(info.Version, "+dirty") {
+				t.Errorf(
+					"Expected version to contain '+dirty', got %q; ensure repository has uncommitted changes",
+					info.Version,
+				)
+			}
+		} else if vcsModified != trueValue {
+			t.Logf("Repository is clean (vcs.modified=%q); make uncommitted changes to cover '+dirty' case", vcsModified)
+		}
+	} else {
+		t.Logf("debug.ReadBuildInfo() failed; ensure tests run in a Git repository to cover VCS parsing")
+	}
+}
+
+func TestGetVersionInfo_InvalidVCSTime(t *testing.T) {
+	Version = devVersion
+	Commit = unknownValue
+	Date = unknownValue
+
+	info := GetMetaInfo()
+
+	if info.Date == "" || info.Date != unknownValue {
+		t.Errorf("Expected date to be %q, got %q", unknownValue, info.Date)
+	}
+}
+
+func TestContains(t *testing.T) {
+	tests := []struct {
+		name     string
+		s        string
+		substr   string
+		expected bool
+	}{
+		{
+			name:     "Substring found",
+			s:        "v1.0.0+dirty",
+			substr:   "+dirty",
+			expected: true,
+		},
+		{
+			name:     "Substring not found",
+			s:        "v1.0.0",
+			substr:   "+dirty",
+			expected: false,
+		},
+		{
+			name:     "Empty string",
+			s:        "",
+			substr:   "+dirty",
+			expected: false,
+		},
+		{
+			name:     "Empty substring",
+			s:        "v1.0.0",
+			substr:   "",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := contains(tt.s, tt.substr)
+			if result != tt.expected {
+				t.Errorf("contains(%q, %q) = %v, want %v", tt.s, tt.substr, result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/meta/version.go
+++ b/internal/meta/version.go
@@ -1,7 +1,0 @@
-package meta
-
-// Version of Shoutrrr.
-const Version = `0.6-dev`
-
-// DocsVersion is prepended to documentation URLs and usually equals MAJOR.MINOR of Version.
-const DocsVersion = `dev`

--- a/pkg/util/docs.go
+++ b/pkg/util/docs.go
@@ -14,5 +14,11 @@ func DocsURL(path string) string {
 		path = path[1:]
 	}
 
-	return fmt.Sprintf("https://nicholas-fedor.github.io/shoutrrr/%s/%s", meta.DocsVersion, path)
+	// Use commit for dev builds, version for releases
+	version := meta.GetVersion()
+	if version == "unknown" || version == "dev" {
+		version = meta.GetCommit()
+	}
+
+	return fmt.Sprintf("https://nicholas-fedor.github.io/shoutrrr/%s/%s", version, path)
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -92,7 +92,7 @@ var _ = ginkgo.Describe("the util package", func() {
 		ginkgo.It("should return the expected URL", func() {
 			expectedBase := fmt.Sprintf(
 				`https://nicholas-fedor.github.io/shoutrrr/%s/`,
-				meta.DocsVersion,
+				meta.GetVersion(),
 			)
 			gomega.Expect(util.DocsURL(``)).To(gomega.Equal(expectedBase))
 			gomega.Expect(util.DocsURL(`services/logger`)).

--- a/shoutrrr.go
+++ b/shoutrrr.go
@@ -50,7 +50,7 @@ func NewSender(logger types.StdLogger, serviceURLs ...string) (*router.ServiceRo
 	return sr, nil
 }
 
-// Version returns the current shoutrrr version.
+// Version returns the current Shoutrrr version.
 func Version() string {
-	return meta.Version
+	return meta.GetVersion()
 }

--- a/shoutrrr/main.go
+++ b/shoutrrr/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -15,9 +16,8 @@ import (
 )
 
 var cobraCmd = &cobra.Command{
-	Use:     "shoutrrr",
-	Version: meta.Version,
-	Short:   "Shoutrrr CLI",
+	Use:   "shoutrrr",
+	Short: "Shoutrrr CLI",
 }
 
 func init() {
@@ -26,6 +26,13 @@ func init() {
 	cobraCmd.AddCommand(generate.Cmd)
 	cobraCmd.AddCommand(send.Cmd)
 	cobraCmd.AddCommand(docs.Cmd)
+
+	cobraCmd.Version = fmt.Sprintf(
+		"%s (Built on %s from Git SHA %s)",
+		meta.GetVersion(),
+		meta.GetDate(),
+		meta.GetCommit(),
+	)
 }
 
 func main() {


### PR DESCRIPTION
This PR provides improved handling of metadata, such as version information, for Shoutrrr. 
It improves the use of build flags and ensures that the `shoutrrr --version` command + flag provides accurate build information.
This applies either when building locally or with Goreleaser. If running via `go run ./shoutrrr/main.go`, then `unknown` values will be used.
Additional testing has been provided for this functionality.
The changes should not be breaking.
This resolves issue https://github.com/nicholas-fedor/shoutrrr/issues/123.