### PR TITLE
Pull Request: Enhance Version Metadata Handling for `go install` and Goreleaser Builds

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -14,7 +14,7 @@ builds:
     ldflags:
       - -s -w
       - -X github.com/nicholas-fedor/shoutrrr/internal/meta.Version={{ .Version }}
-      - -X github.com/nicholas-fedor/shoutrrr/internal/meta.Commit={{.ShortCommit}}
+      - -X github.com/nicholas-fedor/shoutrrr/internal/meta.Commit={{.Commit}}
       - -X github.com/nicholas-fedor/shoutrrr/internal/meta.Date={{.Date}}
 
 archives:

--- a/shoutrrr/main.go
+++ b/shoutrrr/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -27,12 +26,7 @@ func init() {
 	cobraCmd.AddCommand(send.Cmd)
 	cobraCmd.AddCommand(docs.Cmd)
 
-	cobraCmd.Version = fmt.Sprintf(
-		"%s (Built on %s from Git SHA %s)",
-		meta.GetVersion(),
-		meta.GetDate(),
-		meta.GetCommit(),
-	)
+	cobraCmd.Version = meta.GetMetaStr()
 }
 
 func main() {


### PR DESCRIPTION
## Description
This pull request addresses [issue #125](https://github.com/nicholas-fedor/shoutrrr/issues/125), where `go install` commands (`go install github.com/nicholas-fedor/shoutrrr/shoutrrr@latest` or `@v0.8.10`) produced incorrect version metadata (`shoutrrr version v0.8.10 (Built on unknown from Git SHA unknown)`). The changes ensure that `go install` builds display a clean version string (e.g., `v0.8.10 (Built on 2025-05-27)`) while maintaining full metadata for Goreleaser builds (e.g., `v0.8.10 (Built on 2025-05-27 from Git SHA a6fcf77)`). Additionally, linting issues and test failures were resolved to improve code quality.

## Changes
- **meta.go**:
  - Added `GetMetaStr()` to dynamically format the version string, omitting commit info when unavailable (e.g., for `go install`).
  - Updated `GetDate()` to use `time.Now().UTC().Format("2006-01-02")` as a fallback, ensuring a valid `YYYY-MM-DD` date.
  - Refactored `GetCommit()` to simplify logic and replace hardcoded `7` with `commitSHALength` constant to fix `mnd` linting issues.
- **main.go**:
  - Changed `cobraCmd.Version` to use `meta.GetMetaStr()` for consistent version formatting.
- **meta_test.go**:
  - Updated tests to expect `YYYY-MM-DD` dates instead of `unknown` for `GetDate()` fallback.
  - Added `TestGetMetaStr` to verify version string formatting for both `go install` and Goreleaser cases.
  - Fixed `printf` error in `TestGetVersionInfo_VCSData` by adding missing `vcsTime` argument to `t.Logf`.
- **goreleaser.yml**:
  - Reverted prior change to now use `Commit` instead of `ShortCommit`.

## Related Issue
- Closes #125