### PR TITLE
Update golangci-lint and ensure compliance with updated linting rules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,43 @@
+# Normalize all text files to LF line endings
+* text=auto eol=lf
+
+# Explicitly set Go-related text files to LF
+*.go text eol=lf
+*.mod text eol=lf
+*.sum text eol=lf
+*.work text eol=lf
+*.md text eol=lf
+*.txt text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+*.json text eol=lf
+*.proto text eol=lf
+
+# Treat configuration and script files as text with LF
+*.toml text eol=lf
+*.ini text eol=lf
+*.sh text eol=lf
+Dockerfile text eol=lf
+*.dockerignore text eol=lf
+*.gitignore text eol=lf
+*.gitattributes text eol=lf
+
+# Treat binary files as binary (no line-ending conversion or diff)
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.zip binary
+*.tar binary
+*.gz binary
+*.exe binary
+*.dll binary
+*.so binary
+*.db binary
+*.sqlite binary
+
+# Ensure generated Go binaries or test caches are treated as binary
+*.out binary
+*.test binary

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -50,7 +50,7 @@ linters:
     - usestdlibvars # A linter that detect the possibility to use variables/constants from the Go standard library.
     - usetesting # Reports uses of functions with replacement inside the testing package.
     - whitespace # Whitespace is a linter that checks for unnecessary newlines at the start and end of functions, if, for, etc.
-    - wsl # Add or remove empty lines.
+    - wsl_v5 # Add or remove empty lines.
     ##################################################################################################
     # Enabled linters that require manual issue resolution
     - asasalint # Check for pass []any as any in variadic func(...any).
@@ -208,6 +208,21 @@ linters:
           - promlinter
           - wrapcheck
           - varnamelen
+      # Exclude revive from flagging the internal/util package's name.
+      - path: "internal/util/.*"
+        linters:
+          - revive
+        text: "avoid meaningless package names"
+      # Exclude revive from flagging the pkg/util package's name.
+      - path: "pkg/util/.*"
+        linters:
+          - revive
+        text: "avoid meaningless package names"
+      # Exclude revive from flagging the pkg/types package's name.
+      - path: "pkg/types/.*"
+        linters:
+          - revive
+        text: "avoid meaningless package names"
 
       # Run some linter only for test files by excluding its issues for everything else.
       # - path-except: _test\.go

--- a/pkg/format/format_query.go
+++ b/pkg/format/format_query.go
@@ -34,7 +34,6 @@ func BuildQueryWithCustomFields(cqr types.ConfigQueryResolver, query url.Values)
 		}
 
 		value, err := cqr.Get(key)
-
 		if err != nil || isPkr && pkr.IsDefault(key, value) {
 			continue
 		}

--- a/pkg/router/router_suite_test.go
+++ b/pkg/router/router_suite_test.go
@@ -149,6 +149,7 @@ func ExampleServiceRouter_Enqueue() {
 	}
 
 	defer sr.Flush(nil)
+
 	sr.Enqueue("hello")
 	sr.Enqueue("world")
 	// Output:

--- a/pkg/services/discord/discord_config.go
+++ b/pkg/services/discord/discord_config.go
@@ -42,6 +42,7 @@ type Config struct {
 // LevelColors returns an array of colors indexed by MessageLevel.
 func (config *Config) LevelColors() [types.MessageLevelCount]uint {
 	var colors [types.MessageLevelCount]uint
+
 	colors[types.Unknown] = config.Color
 	colors[types.Error] = config.ColorError
 	colors[types.Warning] = config.ColorWarn

--- a/pkg/services/slack/slack.go
+++ b/pkg/services/slack/slack.go
@@ -124,6 +124,7 @@ func (service *Service) sendWebhook(config *Config, payload any) error {
 	}
 
 	defer res.Body.Close()
+
 	resBytes, _ := io.ReadAll(res.Body)
 	response := string(resBytes)
 

--- a/pkg/services/teams/teams_service.go
+++ b/pkg/services/teams/teams_service.go
@@ -53,6 +53,7 @@ func (service *Service) GetID() string {
 // GetConfigURLFromCustom converts a custom URL to a service URL.
 func (service *Service) GetConfigURLFromCustom(customURL *url.URL) (*url.URL, error) {
 	webhookURLStr := strings.TrimPrefix(customURL.String(), "teams+")
+
 	tempURL, err := url.Parse(webhookURLStr)
 	if err != nil {
 		return nil, fmt.Errorf("parsing custom URL %q: %w", webhookURLStr, err)

--- a/pkg/util/jsonclient/jsonclient.go
+++ b/pkg/util/jsonclient/jsonclient.go
@@ -139,6 +139,7 @@ func (c *client) ErrorResponse(err error, response any) bool {
 // parseResponse parses the HTTP response and unmarshals it into the provided object.
 func parseResponse(res *http.Response, response any) error {
 	defer res.Body.Close()
+
 	body, err := io.ReadAll(res.Body)
 
 	if res.StatusCode >= HTTPClientErrorThreshold {

--- a/shoutrrr/cmd/docs/docs.go
+++ b/shoutrrr/cmd/docs/docs.go
@@ -40,8 +40,8 @@ func init() {
 
 func Run(cmd *cobra.Command, args []string) {
 	format, _ := cmd.Flags().GetString("format")
-	res := printDocs(format, args)
 
+	res := printDocs(format, args)
 	if res.ExitCode != 0 {
 		fmt.Fprintf(os.Stderr, "%s", res.Message)
 	}


### PR DESCRIPTION
This pull request includes an update to the whitespace linter for golangci-lint. In addition, the linter has been run to ensure compliance with the updated configuration. A gitattributes file has also been added to help provide some Git standardization.