### PR TITLE
feat(renovate): enable Go version updates with gomodTidy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,16 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices"],
-  "dependencyDashboard": true,
-  "automerge": true,
+  "extends": ["config:best-practices", ":semanticCommits"],
+  "postUpdateOptions": ["gomodTidy"],
   "packageRules": [
-      {
+    {
+      "matchManagers": ["gomod"],
+      "matchDepNames": ["go"],
+      "matchDepTypes": ["golang"],
+      "rangeStrategy": "bump",
+      "semanticCommitType": "feat"
+    },
+    {
       "description": "Automerge non-major updates",
       "matchUpdateTypes": ["minor", "patch", "digest"],
       "automerge": true


### PR DESCRIPTION
Configure Renovate to automatically update the Go version in go.mod and run go mod tidy after updates. Add package rule to bump Go version with semantic feat commits and enable gomodTidy post-update option.