### PR TITLE
fix(ci): add executable permissions for generate-service-config-docs.sh

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -36,6 +36,9 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      - name: Set executable permissions for script
+        run: chmod +x ./scripts/generate-service-config-docs.sh
+
       - name: Generate Service Config Docs
         run: |
           go mod download


### PR DESCRIPTION
## Description
Fixes permission denied error in publish-docs workflow by setting executable permissions for generate-service-config-docs.sh.

## Changes
- Added chmod +x step for scripts/generate-service-config-docs.sh in publish-docs.yaml