### PR TITLE
fix(docs): correct binary extraction for Linux and macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ Install the latest release binary to `$HOME/go/bin` (ensure it's in your `PATH`)
 - **Linux (amd64):**
 
   ```bash
-  curl -L $(curl -s https://api.github.com/repos/nicholas-fedor/shoutrrr/releases/latest | grep -o -E "https://.*linux_amd64.*\.tar\.gz") | tar -xz -C $HOME/go/bin shoutrrr
+  mkdir -p $HOME/go/bin && curl -L $(curl -s https://api.github.com/repos/nicholas-fedor/shoutrrr/releases/latest | grep -o 'https://[^"]*linux_amd64[^"]*\.tar\.gz') | tar -xz --strip-components=1 -C $HOME/go/bin shoutrrr
   ```
 
 - **macOS (amd64):**
 
   ```bash
-  curl -L $(curl -s https://api.github.com/repos/nicholas-fedor/shoutrrr/releases/latest | grep -o -E "https://.*darwin_amd64.*\.tar\.gz") | tar -xz -C $HOME/go/bin shoutrrr
+  mkdir -p $HOME/go/bin && curl -L $(curl -s https://api.github.com/repos/nicholas-fedor/shoutrrr/releases/latest | grep -o 'https://[^"]*darwin_amd64[^"]*\.tar\.gz') | tar -xz --strip-components=1 -C $HOME/go/bin shoutrrr
   ```
 
 > [!Note]

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -27,13 +27,13 @@ The following scripts install the latest release binary to the user's `$HOME/go/
 === "Linux (amd64)"
 
     ```bash title="Linux (amd64) Installation"
-    curl -L $(curl -s https://api.github.com/repos/nicholas-fedor/shoutrrr/releases/latest | grep -o -E "https://.*linux_amd64.*\.tar\.gz") | tar -xz -C $HOME/go/bin shoutrrr
+    mkdir -p $HOME/go/bin && curl -L $(curl -s https://api.github.com/repos/nicholas-fedor/shoutrrr/releases/latest | grep -o 'https://[^"]*linux_amd64[^"]*\.tar\.gz') | tar -xz --strip-components=1 -C $HOME/go/bin shoutrrr
     ```
 
 === "macOS (amd64)"
 
     ```bash title="macOS (amd64) Installation"
-    curl -L $(curl -s https://api.github.com/repos/nicholas-fedor/shoutrrr/releases/latest | grep -o -E "https://.*darwin_amd64.*\.tar\.gz") | tar -xz -C $HOME/go/bin shoutrrr
+    mkdir -p $HOME/go/bin && curl -L $(curl -s https://api.github.com/repos/nicholas-fedor/shoutrrr/releases/latest | grep -o 'https://[^"]*darwin_amd64[^"]*\.tar\.gz') | tar -xz --strip-components=1 -C $HOME/go/bin shoutrrr
     ```
 <!-- markdownlint-restore -->
 !!! Note


### PR DESCRIPTION
## Description
Fixed the Linux and macOS installation commands in README.md and index.md to extract the `shoutrrr` binary directly to `$HOME/go/bin` using `grep` for URL extraction.

## Changes
- Added `--strip-components=1` to `tar` command to remove top-level directory
- Updated Linux and macOS commands to use `grep` for URL extraction
- Updated `README.md` and `index.md` with corrected commands