### PR TITLE
fix(Dockerfile): Add tzdata and ARG BASE_IMAGE in scratch stage

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -5,9 +5,12 @@ ARG GOARCH
 FROM --platform=$BUILDPLATFORM $BASE_IMAGE AS builder
 
 RUN apk add --no-cache \
-    ca-certificates
+    ca-certificates \
+    tzdata
 
 FROM scratch
+
+ARG BASE_IMAGE
 
 LABEL "org.opencontainers.image.url"="https://nicholas-fedor.github.io/shoutrrr/" \
     "org.opencontainers.image.documentation"="https://nicholas-fedor.github.io/shoutrrr/" \
@@ -15,7 +18,7 @@ LABEL "org.opencontainers.image.url"="https://nicholas-fedor.github.io/shoutrrr/
     "org.opencontainers.image.licenses"="MIT" \
     "org.opencontainers.image.title"="Shoutrrr" \
     "org.opencontainers.image.description"="A notification library for gophers and their furry friends." \
-    "org.opencontainers.image.base.name"="${BASE_IMAGE:-alpine:3.22.1}"
+    "org.opencontainers.image.base.name"="${BASE_IMAGE}"
 
 # Copy ca-certs and timezone from builder
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
Fixes two issues in `build/docker/Dockerfile` to ensure successful builds and resolve linter warnings.

**Changes**:
- Added `tzdata` to the `builder` stage to provide `/usr/share/zoneinfo`, fixing the Docker build failure in the `release-dev.yaml` workflow.
- Added `ARG BASE_IMAGE` in the `scratch` stage to make `$BASE_IMAGE` available for the `org.opencontainers.image.base.name` label, resolving Buildkit's `UndefinedVar` warning.
- Simplified the `org.opencontainers.image.base.name` label by removing the redundant default value (`${BASE_IMAGE:-alpine:3.22.1}`).