### PR TITLE
chore(ci): Fix permissions and linting issues in GitHub Actions workflows

### DIFF
--- a/.github/workflows/clean-cache.yaml
+++ b/.github/workflows/clean-cache.yaml
@@ -16,14 +16,14 @@ jobs:
       - name: Cleanup
         run: |
           echo "Fetching list of cache key"
-          cacheKeysForPR=$(gh cache list --ref $BRANCH --limit 100 --json id --jq '.[].id')
+          cacheKeysForPR=$(gh cache list --ref "$BRANCH" --limit 100 --json id --jq '.[].id')
 
           ## Setting this to not fail the workflow while deleting cache keys.
           set +e
           echo "Deleting caches..."
-          for cacheKey in $cacheKeysForPR
+          for cacheKey in "$cacheKeysForPR"
           do
-              gh cache delete $cacheKey
+              gh cache delete "$cacheKey"
           done
           echo "Done"
         env:

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -55,13 +55,12 @@ jobs:
           cache-dependency-path: |
             build/mkdocs/docs-requirements.txt
 
-      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
+      - run: echo "cache_id=$(date --utc '+%V')" >> "$GITHUB_ENV"
 
       - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
         with:
           key: mkdocs-material-${{ env.cache_id }}
           path: .cache
-
           restore-keys: |
             mkdocs-material-
 

--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -26,7 +26,7 @@ jobs:
     needs: test # Requires tests to pass
     uses: ./.github/workflows/build.yaml
     permissions:
-      contents: read # For code checkout
+      contents: write # For code checkout and publishing releases
       packages: write # For pushing images to registries
       attestations: write # For generating provenance and SBOMs
       id-token: write # For OIDC auth to Docker Hub and GHCR


### PR DESCRIPTION
## Description
Updated workflow permissions to allow publishing GitHub releases and addressed shellcheck warnings to prevent globbing and word splitting.

## Changes
- Changed contents permission from read to write in build job of release-prod.yaml
- Quoted cacheKeysForPR and cacheKey in clean-cache.yaml
- Quoted GITHUB_ENV in publish-docs.yaml