### PR TITLE
chore(ci): correct workflow permissions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -96,7 +96,7 @@ jobs:
           # Skip publishing during dry-run
           args: release --config build/goreleaser/${{ inputs.build-type }}.yaml ${{ inputs.build-type == 'dev' && '--snapshot' || '' }} --clean ${{ inputs.dry-run && '--skip=publish' || '' }}
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_GHCR_PAT }}
+          GITHUB_TOKEN: ${{ github.token }}
           DRY_RUN: ${{ inputs.dry-run }}
 
       - name: Upload binary SBOMs # Upload SBOMs for prod builds.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: read # For code checkout
+      contents: write # For code checkout and publishing releases
       packages: write # For pushing images to registries
       attestations: write # For generating provenance and SBOMs
       id-token: write # For OIDC auth to Docker Hub and GHCR


### PR DESCRIPTION
- Revert prior commit to use github.token instead of PAT.
- Add contents:write permissions.