### PR TITLE
ci: correct permissions for build

### DIFF
--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -35,7 +35,7 @@ jobs:
     needs: test # Requires tests to pass
     uses: ./.github/workflows/build.yaml
     permissions:
-      contents: read # For code checkout
+      contents: write # For code checkout and uploading release artifacts
       packages: write # For pushing images to registries
       attestations: write # For generating provenance and SBOMs
       id-token: write # For OIDC auth to Docker Hub and GHCR


### PR DESCRIPTION
- Update permissions for build step to write contents for uploading release artifacts.