### PR TITLE
docs: Add Signal and WeCom services to MkDocs navigation

### DIFF
--- a/build/mkdocs/mkdocs.yaml
+++ b/build/mkdocs/mkdocs.yaml
@@ -121,9 +121,11 @@ nav:
           - Matrix: services/matrix/index.md
           - Mattermost: services/mattermost/index.md
           - Rocketchat: services/rocketchat/index.md
+          - Signal: services/signal/index.md
           - Slack: services/slack/index.md
           - Teams: services/teams/index.md
           - Telegram: services/telegram/index.md
+          - WeCom: services/wecom/index.md
           - Zulip Chat: services/zulip/index.md
       - Webhooks:
           - Generic Webhook: services/generic/index.md


### PR DESCRIPTION
Add Signal and WeCom service documentation pages to the MkDocs navigation structure.

## Changes
- Added Signal service to Messaging section in mkdocs.yaml navigation
- Added WeCom service to Messaging section in mkdocs.yaml navigation