### PR TITLE
Fix: Resolve "signals" unknown service error by standardizing TLS configuration

### DIFF
--- a/docs/services/signal/index.md
+++ b/docs/services/signal/index.md
@@ -5,8 +5,6 @@
 !!! info ""
     signal://[__`user`__[:__`password`__]@]__`host`__[:__`port`__]/__`source_phone`__/__`recipient1`__[,__`recipient2`__,...]
 
-    signals://[__`user`__[:__`password`__]@]__`host`__[:__`port`__]/__`source_phone`__/__`recipient1`__[,__`recipient2`__,...]
-
 ## Setting up Signal API Server
 
 Signal notifications require a Signal API server that can send messages on behalf of a registered Signal account. These implementations are built on top of __[signal-cli](https://github.com/AsamK/signal-cli)__, the unofficial command-line interface for Signal (3.8k+ stars).
@@ -60,7 +58,7 @@ Recipients can be:
 ### TLS Configuration
 
 - Use `signal://` for HTTPS (default, recommended)
-- Use `signals://` for HTTP (insecure, for local testing only)
+- Use `signal://...?disabletls=yes` for HTTP (insecure, for local testing only)
 
 ## Examples
 
@@ -97,7 +95,7 @@ signal://localhost:8080/+1234567890/+0987654321?token=YOUR_API_TOKEN
 ### Using HTTP instead of HTTPS
 
 ```
-signals://localhost:8080/+1234567890/+0987654321
+signal://localhost:8080/+1234567890/+0987654321?disabletls=yes
 ```
 
 ## Attachments

--- a/pkg/services/signal/signal_config.go
+++ b/pkg/services/signal/signal_config.go
@@ -64,15 +64,10 @@ func (config *Config) SetURL(url *url.URL) error {
 
 // getURL constructs a URL from the Config's fields using the provided resolver.
 func (config *Config) getURL(resolver types.ConfigQueryResolver) *url.URL {
-	scheme := Scheme
-	if config.DisableTLS {
-		scheme = "signals" // Use signals for non-TLS
-	}
-
 	recipients := strings.Join(config.Recipients, "/")
 
 	result := &url.URL{
-		Scheme:   scheme,
+		Scheme:   Scheme,
 		Host:     fmt.Sprintf("%s:%d", config.Host, config.Port),
 		Path:     fmt.Sprintf("/%s/%s", config.Source, recipients),
 		RawQuery: format.BuildQuery(resolver),
@@ -118,8 +113,6 @@ func (config *Config) setURL(resolver types.ConfigQueryResolver, serviceURL *url
 	if err := config.parseQuery(resolver, serviceURL); err != nil {
 		return err
 	}
-
-	config.setTLS(serviceURL)
 
 	return nil
 }
@@ -191,11 +184,6 @@ func (config *Config) parseQuery(resolver types.ConfigQueryResolver, serviceURL 
 	}
 
 	return nil
-}
-
-// setTLS configures TLS settings based on the URL scheme.
-func (config *Config) setTLS(serviceURL *url.URL) {
-	config.DisableTLS = serviceURL.Scheme == "signals"
 }
 
 // isValidPhoneNumber checks if the string is a valid phone number.

--- a/pkg/services/signal/signal_test.go
+++ b/pkg/services/signal/signal_test.go
@@ -105,15 +105,17 @@ var _ = ginkgo.Describe("the signal service", func() {
 			})
 
 			ginkgo.When("parsing TLS settings", func() {
-				ginkgo.It("should enable TLS for signal:// scheme", func() {
+				ginkgo.It("should enable TLS by default", func() {
 					serviceURL, _ := url.Parse("signal://localhost:8080/+1234567890/+0987654321")
 					err := signal.Initialize(serviceURL, logger)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					gomega.Expect(signal.Config.DisableTLS).To(gomega.BeFalse())
 				})
 
-				ginkgo.It("should disable TLS for signals:// scheme", func() {
-					serviceURL, _ := url.Parse("signals://localhost:8080/+1234567890/+0987654321")
+				ginkgo.It("should disable TLS when disabletls=yes", func() {
+					serviceURL, _ := url.Parse(
+						"signal://localhost:8080/+1234567890/+0987654321?disabletls=yes",
+					)
 					err := signal.Initialize(serviceURL, logger)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					gomega.Expect(signal.Config.DisableTLS).To(gomega.BeTrue())


### PR DESCRIPTION
This PR addresses GitHub issue #322 where users encountered an "unknown service: signals" error when trying to use the `signals://` scheme. The issue was caused by inconsistent TLS handling in the signal service compared to other services in the codebase.

The solution standardizes the signal service to use the same pattern as gotify and other services by using the `disabletls` query parameter instead of a separate URL scheme for HTTP connections.

## Changes

**Core Service Changes:**
- `pkg/services/signal/signal_config.go`
  - Removed `setTLS()` method that relied on scheme detection
  - Modified `getURL()` to always use `signal://` scheme regardless of TLS setting
  - Removed scheme-based TLS logic for consistency

**Test Updates:**
- `pkg/services/signal/signal_test.go`
  - Updated TLS configuration tests to use `?disabletls=yes` parameter
  - Removed tests that relied on `signals://` scheme

**Documentation Updates:**
- `docs/services/signal/index.md`
  - Removed `signals://` scheme from URL format documentation
  - Updated TLS configuration section to show `?disabletls=yes` usage
  - Updated examples to use query parameter instead of different scheme

Closes #322