### PR TITLE
ci: add checkout step to clean-cache workflow

### DIFF
--- a/.github/workflows/clean-cache.yaml
+++ b/.github/workflows/clean-cache.yaml
@@ -14,6 +14,8 @@ jobs:
     if: github.event.pull_request.merged
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - uses: ./.github/actions/clean-cache
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Add `actions/checkout@v4` as the first step in the cleanup job
- Ensures repository code is available before executing the local clean-cache action
- Resolves error where GitHub Actions couldn't find `action.yml` in `.github/actions/clean-cache`