### PR TITLE
fix: secure Teams webhook URL validation against unintended host matches

### DIFF
--- a/pkg/services/chat/teams/teams_config.go
+++ b/pkg/services/chat/teams/teams_config.go
@@ -51,7 +51,7 @@ func (config *Config) SetFromWebhookURL(webhookURL string) error {
 		return ErrInvalidWebhookFormat
 	}
 
-	config.Host = orgGroups[1] + WebhookDomain
+	config.Host = orgGroups[1] + ".webhook.office.com"
 
 	parts, err := ParseAndVerifyWebhookURL(webhookURL)
 	if err != nil {

--- a/pkg/services/chat/teams/teams_validation.go
+++ b/pkg/services/chat/teams/teams_validation.go
@@ -9,7 +9,7 @@ import (
 const (
 	UUID4Length        = 36 // Length of a UUID4 identifier
 	HashLength         = 32 // Length of a hash identifier
-	WebhookDomain      = ".webhook.office.com"
+	WebhookDomain      = `\.webhook\.office\.com`
 	ExpectedComponents = 7 // Expected number of components in webhook URL (1 match + 6 captures)
 	Path               = "webhookb2"
 	ProviderName       = "IncomingWebhook"


### PR DESCRIPTION
This PR addresses security vulnerabilities in the Teams service webhook URL validation (CodeQL alerts #35 and #36). The regex patterns contained unescaped dots, allowing unintended hostname matches that could bypass domain restrictions.

## Changes
- **pkg/services/chat/teams/teams_validation.go**: Updated `WebhookDomain` constant to use properly escaped dots (`\.webhook\.office\.com`) in the regex pattern.
- **pkg/services/chat/teams/teams_config.go**: Modified `SetFromWebhookURL` to concatenate the host using a plain string (`.webhook.office.com`) instead of the regex-escaped constant, preventing literal backslashes in URL outputs.

## Security Impact
The regex now strictly validates webhook URLs against the intended `webhook.office.com` domain, preventing potential attacks that could match arbitrary subdomains (e.g., `evilwebhook.office.com`).