### PR TITLE
ci(docs): implement mike plugin

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -66,5 +66,26 @@ jobs:
         run: |
           pip install -r build/mkdocs/docs-requirements.txt
 
+      - name: Determine Mike Version and Aliases
+        id: mike
+        run: |
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            echo "version=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+            echo "aliases=latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=dev" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build and Deploy
-        run: mkdocs gh-deploy --force --verbose --config-file build/mkdocs/mkdocs.yaml
+        run: |
+          if [ -n "${{ steps.mike.outputs.aliases }}" ]; then
+            mike deploy \
+              --config-file build/mkdocs/mkdocs.yaml \
+              --push \
+              --update-aliases "${{ steps.mike.outputs.version }}" "${{ steps.mike.outputs.aliases }}"
+          else
+            mike deploy \
+              --config-file build/mkdocs/mkdocs.yaml \
+              --push \
+              "${{ steps.mike.outputs.version }}"
+          fi

--- a/build/mkdocs/mkdocs.yaml
+++ b/build/mkdocs/mkdocs.yaml
@@ -43,8 +43,13 @@ theme:
 # Extra Configuration: Passed to templates for flexibility.
 extra:
   # Version provider for the mike plugin to handle versioned documentation.
+  # https://squidfunk.github.io/mkdocs-material/setup/setting-up-versioning/#versioning
   version:
     provider: mike
+    alias: true
+    default:
+      - latest
+      - dev
   # Disables the "Made with MkDocs" generator text in the footer.
   generator: false
   # Social links displayed as icons in the footer (Material theme).


### PR DESCRIPTION
This pull request implements the Mike plugin to provide documentation versioning.

## Changes

- Update mkdocs deployment workflows to use Mike instead
- Add versioning configuration to mkdocs