### PR TITLE
ci: enable check-latest for go setup in workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,6 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@c0137caad775660c0844396c52da96e560aba63d
         with:
+          check-latest: true
           go-version: 1.25.x
 
       - name: Set up QEMU # Enable multi-platform emulation.

--- a/.github/workflows/lint-go.yaml
+++ b/.github/workflows/lint-go.yaml
@@ -22,6 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@c0137caad775660c0844396c52da96e560aba63d
         with:
+          check-latest: true
           go-version: ${{ env.GO_VERSION }}
           cache: true
           cache-dependency-path: "**/go.sum"

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -33,6 +33,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@c0137caad775660c0844396c52da96e560aba63d
         with:
+          check-latest: true
           go-version: ${{ env.GO_VERSION }}
 
       - name: Set executable permissions for script

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,6 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@c0137caad775660c0844396c52da96e560aba63d
         with:
+          check-latest: true
           go-version: ${{ matrix.go-version }}
           cache: true
           cache-dependency-path: "**/go.sum"


### PR DESCRIPTION
Add check-latest: true to the actions/setup-go step in build, lint-go, publish-docs, and test workflows to ensure the latest version is used.