### PR TITLE
ci: add PR baseline checkout logic for gosec and govulncheck

### DIFF
--- a/.github/actions/gosec/action.yml
+++ b/.github/actions/gosec/action.yml
@@ -1,15 +1,48 @@
 name: "Golang Security Checker"
 description: "Run Gosec security scanner and upload SARIF report"
 
+inputs:
+  go-version:
+    description: "Go version to use"
+    required: false
+    default: "1.25.x"
+
 runs:
   using: "composite"
   steps:
-    - name: Checkout Source
-      uses: ./.github/actions/checkout
-    - name: Run Gosec Security Scanner
-      uses: securego/gosec@6be2b51fd78feca86af91f5186b7964d76cb1256 # v2.22.10
+    - uses: actions/setup-go@c0137caad775660c0844396c52da96e560aba63d
       with:
-        args: "-no-fail -fmt sarif -out results.sarif -tests ./..."
+        go-version: ${{ inputs.go-version }}
+
+    - name: Install gosec
+      shell: bash
+      run: go install github.com/securego/gosec/v2/cmd/gosec@latest
+
+    - name: Checkout main branch
+      if: github.event_name == 'pull_request'
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+      with:
+        ref: "main"
+        fetch-depth: 0
+        path: "main"
+
+    - name: Run gosec on main
+      if: github.event_name == 'pull_request'
+      shell: bash
+      run: |
+        cd main
+        gosec -no-fail -fmt sarif -out ../main.sarif -tests ./...
+
+    - name: Run gosec on PR
+      if: github.event_name == 'pull_request'
+      shell: bash
+      run: gosec -no-fail -fmt sarif -baseline main.sarif -out results.sarif -tests ./...
+
+    - name: Run gosec on push
+      if: github.event_name != 'pull_request'
+      shell: bash
+      run: gosec -no-fail -fmt sarif -out results.sarif -tests ./...
+
     - name: Upload SARIF file
       uses: github/codeql-action/upload-sarif@16140ae1a102900babc80a33c44059580f687047 # v4
       with:

--- a/.github/actions/govulncheck/action.yml
+++ b/.github/actions/govulncheck/action.yml
@@ -10,12 +10,38 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - id: govulncheck
-      uses: nicholas-fedor/govulncheck-action@1e9ef2cbd93abefcc8605e05f8c212aa90181f6f
+    - uses: actions/setup-go@c0137caad775660c0844396c52da96e560aba63d
       with:
-        output-format: sarif
-        output-file: results.sarif
-        go-version-input: ${{ inputs.go-version }}
+        go-version: ${{ inputs.go-version }}
+
+    - name: Install govulncheck
+      shell: bash
+      run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+    - name: Checkout main branch
+      if: github.event_name == 'pull_request'
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+      with:
+        ref: "main"
+        fetch-depth: 0
+        path: "main"
+
+    - name: Run govulncheck on main
+      if: github.event_name == 'pull_request'
+      shell: bash
+      run: |
+        cd main
+        govulncheck -format sarif -out ../main.sarif ./...
+
+    - name: Run govulncheck
+      shell: bash
+      run: |
+        if [ "${{ github.event_name }}" == "pull_request" ]; then
+          govulncheck -format sarif -baseline main.sarif -out results.sarif ./...
+        else
+          govulncheck -format sarif -out results.sarif ./...
+        fi
+
     - name: Upload SARIF file
       uses: github/codeql-action/upload-sarif@16140ae1a102900babc80a33c44059580f687047 # v4
       with:


### PR DESCRIPTION
- Modify gosec action to include PR baseline checkout for code scanning
- Modify govulncheck action to include PR baseline checkout for code scanning
- Fix "configuration not found" issue by enabling baseline comparison
- Enable proper identification of newly introduced security issues in pull requests