### PR TITLE
ci: correct flags in gosec and govulncheck actions

### DIFF
--- a/.github/actions/gosec/action.yml
+++ b/.github/actions/gosec/action.yml
@@ -31,12 +31,12 @@ runs:
       shell: bash
       run: |
         cd main
-        gosec -no-fail -fmt sarif -out ../main.sarif -tests ./...
+        gosec -no-fail -fmt sarif -out results.sarif -tests ./...
 
     - name: Run gosec on PR
       if: github.event_name == 'pull_request'
       shell: bash
-      run: gosec -no-fail -fmt sarif -baseline main.sarif -out results.sarif -tests ./...
+      run: gosec -no-fail -fmt sarif -out results.sarif -tests ./...
 
     - name: Run gosec on push
       if: github.event_name != 'pull_request'

--- a/.github/actions/govulncheck/action.yml
+++ b/.github/actions/govulncheck/action.yml
@@ -31,15 +31,15 @@ runs:
       shell: bash
       run: |
         cd main
-        govulncheck -format sarif -out ../main.sarif ./...
+        govulncheck -format sarif ./... > ../main.sarif
 
     - name: Run govulncheck
       shell: bash
       run: |
         if [ "${{ github.event_name }}" == "pull_request" ]; then
-          govulncheck -format sarif -baseline main.sarif -out results.sarif ./...
+          govulncheck -format sarif -baseline main.sarif ./... > results.sarif
         else
-          govulncheck -format sarif -out results.sarif ./...
+          govulncheck -format sarif ./... > results.sarif
         fi
 
     - name: Upload SARIF file


### PR DESCRIPTION
ci: correct flags in gosec and govulncheck actions

- fix invalid -out flag in govulncheck by using shell redirection
- remove unsupported -baseline flag from gosec
- adjust output file name for gosec to match workflow