### PR TITLE
ci: correct flags in gosec and govulncheck actions

### DIFF
--- a/.github/actions/gosec/action.yml
+++ b/.github/actions/gosec/action.yml
@@ -31,17 +31,17 @@ runs:
       shell: bash
       run: |
         cd main
-        gosec -no-fail -fmt sarif -out results.sarif -tests ./...
+        gosec -no-fail -fmt sarif -out results.sarif -ai-api-key "" -tests ./...
 
     - name: Run gosec on PR
       if: github.event_name == 'pull_request'
       shell: bash
-      run: gosec -no-fail -fmt sarif -out results.sarif -tests ./...
+      run: gosec -no-fail -fmt sarif -out results.sarif -ai-api-key "" -tests ./...
 
     - name: Run gosec on push
       if: github.event_name != 'pull_request'
       shell: bash
-      run: gosec -no-fail -fmt sarif -out results.sarif -tests ./...
+      run: gosec -no-fail -fmt sarif -out results.sarif -ai-api-key "" -tests ./...
 
     - name: Upload SARIF file
       uses: github/codeql-action/upload-sarif@16140ae1a102900babc80a33c44059580f687047 # v4

--- a/.github/actions/govulncheck/action.yml
+++ b/.github/actions/govulncheck/action.yml
@@ -37,7 +37,7 @@ runs:
       shell: bash
       run: |
         if [ "${{ github.event_name }}" == "pull_request" ]; then
-          govulncheck -format sarif -baseline main.sarif ./... > results.sarif
+          govulncheck -format sarif ./... > results.sarif
         else
           govulncheck -format sarif ./... > results.sarif
         fi


### PR DESCRIPTION
- remove invalid -baseline flag from govulncheck
- add -ai-api-key "" to gosec to disable AI features and fix SARIF validation