### PR TITLE
docs: fix relative link paths in service docs

### DIFF
--- a/docs/services/chat/slack/index.md
+++ b/docs/services/chat/slack/index.md
@@ -8,7 +8,7 @@
 The Slack notification service uses either [Slack Webhooks](https://api.slack.com/messaging/webhooks) or the
 [Bot API](https://api.slack.com/methods/chat.postMessage) to send messages.
 
-See the [guides](../../guides/slack/index.md) for information on how to get your *token*.
+See the [guides](../../../guides/slack/index.md) for information on how to get your *token*.
 
 ## URL Format
 

--- a/docs/services/specialized/generic/index.md
+++ b/docs/services/specialized/generic/index.md
@@ -5,7 +5,7 @@ supports receiving the message via a POST request.
 Usually, this requires customization on the receiving end to interpret the payload that it receives, and might
 not be a viable approach.
 
-Common examples for use with service providers can be found under [examples](../../examples/home-assistant/index.md).
+Common examples for use with service providers can be found under [examples](../../../examples/home-assistant/index.md).
 
 ## Custom headers
 


### PR DESCRIPTION
Corrects broken relative links in Slack and generic service docs to point to the correct guides and examples directories.

## Changes

- Update Slack service documentation link to guides
- Update generic service documentation link to examples