### PR TITLE
Split required Go version from Go toolchain selection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/nicholas-fedor/shoutrrr
 
 go 1.25
 
-toolchain 1.25.4
+toolchain go1.25.4
 
 require (
 	github.com/jarcoal/httpmock v1.4.1


### PR DESCRIPTION
- For https://github.com/StackExchange/dnscontrol/pull/3838#discussion_r2539801899

Docs:
- https://go.dev/doc/modules/gomod-ref#go
- https://go.dev/doc/toolchain

Using `go MAJOR.MINOR`  will set the minimum required Go version. Using `go MAJOR.MINOR.PATCH`  will select a specific toolchain.

The former allows downstream consumers of this library to pick any version that satisfies the minimum `MAJOR.MINOR` version in their `go.mod` file.

The later requires all downstream consumers to set at least `MAJOR.MINOR.PATCH` in their `go.mod` file. Effectively forcing every downstream consumer to start pinning patch versions.

This patch is reversing course here to avoid pinning patch versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Go build/toolchain configuration to standardize and simplify version declaration, aligning declared version with the toolchain metadata for more consistent builds and developer tooling behavior.
  * No runtime or public API changes included.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->