### PR TITLE
ci(renovate): Add Renovate rule for Go toolchain updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,10 +4,18 @@
   "postUpdateOptions": ["gomodTidy"],
   "packageRules": [
     {
+      "description": "Handle Go version updates",
       "matchManagers": ["gomod"],
       "matchDepNames": ["go"],
       "matchDepTypes": ["golang"],
       "rangeStrategy": "bump",
+      "semanticCommitType": "chore"
+    },
+    {
+      "description": "Handle Go toolchain updates",
+      "matchManagers": ["gomod"],
+      "matchDepNames": ["toolchain"],
+      "rangeStrategy": "pin",
       "semanticCommitType": "chore"
     },
     {


### PR DESCRIPTION
- Add rule to handle Go toolchain version updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated dependency update configuration for Go version and toolchain management to improve build environment consistency and update handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->