### PR TITLE
ci: Remove unused Go version input

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -54,5 +54,3 @@ jobs:
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
       - uses: ./.github/actions/govulncheck
-        with:
-          go-version: 1.25.x


### PR DESCRIPTION
- Remove go-version input from govulncheck job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to streamline build process.

---

**Note:** This release contains no user-visible changes. Updates are internal to development infrastructure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->