### PR TITLE
chore: Restore Go toolchain separation

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,6 +8,7 @@
       "matchManagers": ["gomod"],
       "matchDepNames": ["go"],
       "matchDepTypes": ["golang"],
+      "matchUpdateTypes": ["major", "minor"],
       "rangeStrategy": "bump",
       "semanticCommitType": "chore"
     },

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/nicholas-fedor/shoutrrr
 
-go 1.25.5
+go 1.25
+
+toolchain go1.25.5
 
 require (
 	github.com/jarcoal/httpmock v1.4.1


### PR DESCRIPTION
- Update go.mod to use Go 1.25 with explicit toolchain go1.25.5
- Configure Renovate to allow major and minor updates for Go

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go version management configuration to restrict automated updates to major and minor versions only.
  * Refined Go toolchain specification for improved build consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->