### PR TITLE
fix(smtp): Fix SMTP session closure error that causes false notification failures

### DIFF
--- a/pkg/services/email/smtp/smtp.go
+++ b/pkg/services/email/smtp/smtp.go
@@ -23,12 +23,13 @@ import (
 )
 
 const (
-	contentHTML      = "text/html; charset=\"UTF-8\""
-	contentPlain     = "text/plain; charset=\"UTF-8\""
-	contentMultipart = "multipart/alternative; boundary=%s"
-	DefaultSMTPPort  = 25 // DefaultSMTPPort is the standard port for SMTP communication.
-	boundaryByteLen  = 8  // boundaryByteLen is the number of bytes for the multipart boundary.
-	DefaultTimeout   = 10 // DefaultTimeout is the default timout in seconds
+	contentHTML                 = "text/html; charset=\"UTF-8\""
+	contentPlain                = "text/plain; charset=\"UTF-8\""
+	contentMultipart            = "multipart/alternative; boundary=%s"
+	DefaultSMTPPort             = 25               // DefaultSMTPPort is the standard port for SMTP communication.
+	boundaryByteLen             = 8                // boundaryByteLen is the number of bytes for the multipart boundary.
+	DefaultTimeout              = 10               // DefaultTimeout is the default timout in seconds
+	shortResponseErrorSubstring = "short response" // Error substring from textproto indicating a short response that is sometimes received during session closure.
 )
 
 // ErrNoAuth is a sentinel error indicating no authentication is required.
@@ -209,12 +210,17 @@ func (service *Service) doSend(client *smtp.Client, message string, config *Conf
 	if err := client.Quit(); err != nil {
 		// Ignore known "short response" errors from quirky servers (e.g., Office 365 on close),
 		// as they don't impact delivery.
-		if strings.Contains(err.Error(), "short response") {
+		if strings.Contains(err.Error(), shortResponseErrorSubstring) {
 			service.Logf("Warning: Ignoring session closure error (delivery succeeded): %v", err)
 		} else {
 			// Bubble up other close errors (e.g., network drops)
 			errs = append(errs, fail(FailClosingSession, err))
 		}
+	}
+
+	// Best-effort cleanup to avoid descriptor leaks
+	if closeErr := client.Close(); closeErr != nil {
+		service.Logf("Warning: Failed to close SMTP client connection: %v", closeErr)
 	}
 
 	if len(errs) > 0 {

--- a/pkg/services/email/smtp/smtp_test.go
+++ b/pkg/services/email/smtp/smtp_test.go
@@ -3,7 +3,9 @@ package smtp
 import (
 	"bytes"
 	"context"
+	"errors"
 	"log"
+	"net"
 	"net/smtp"
 	"net/url"
 	"os"
@@ -49,6 +51,30 @@ var (
 	// BasePlusURL is a config with plus signs in email addresses.
 	BasePlusURL = "smtp://user:password@example.com:2225/?useStartTLS=no&fromAddress=sender+tag@example.com&toAddresses=rec1+tag@example.com,rec2@example.com&useHTML=yes&timeout=10s"
 )
+
+// mockConn is a mock implementation of net.Conn that fails on Close for testing purposes.
+type mockConn struct {
+	closeCount int
+}
+
+func (m *mockConn) Read(_ []byte) (int, error)  { return 0, nil }
+func (m *mockConn) Write(b []byte) (int, error) { return len(b), nil }
+func (m *mockConn) Close() error {
+	m.closeCount++
+
+	ginkgo.GinkgoWriter.Write([]byte("mockConn.Close called\n"))
+
+	if m.closeCount > 1 {
+		return errors.New("mock close error")
+	}
+
+	return nil
+}
+func (m *mockConn) LocalAddr() net.Addr                { return nil }
+func (m *mockConn) RemoteAddr() net.Addr               { return nil }
+func (m *mockConn) SetDeadline(_ time.Time) error      { return nil }
+func (m *mockConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (m *mockConn) SetWriteDeadline(_ time.Time) error { return nil }
 
 // modifyURL modifies a base URL by updating query parameters as specified.
 func modifyURL(base string, params map[string]string) string {
@@ -540,6 +566,39 @@ var _ = ginkgo.Describe("the SMTP service", func() {
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 				gomega.Expect(buf.String()).
 					To(gomega.ContainSubstring("Warning: Ignoring session closure error (delivery succeeded)"))
+			})
+			ginkgo.It("should log warning when QUIT succeeds but Close fails", func() {
+				testURL := BaseNoAuthURL
+				serviceURL, _ := url.Parse(testURL)
+				localService := &Service{}
+				err := localService.Initialize(serviceURL, logger)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				var buf bytes.Buffer
+				testLogger := log.New(&buf, "", 0)
+				localService.SetLogger(testLogger)
+				responses := []string{
+					"250-mx.google.com at your service",
+					"250-SIZE 35651584",
+					"250-AUTH LOGIN PLAIN",
+					"250 8BITMIME",
+					"250 Sender OK",
+					"250 Receiver OK",
+					"354 Go ahead",
+					"250 Data OK",
+					"221 OK", // QUIT succeeds
+				}
+				textCon, _ := testutils.CreateTextConFaker(responses, "\r\n")
+				client := &smtp.Client{Text: textCon}
+				fakeTLSEnabled(client, serviceURL.Hostname())
+				// Mock the underlying connection to fail on Close
+				cr := reflect.ValueOf(client).Elem().FieldByName("Text").Elem().FieldByName("conn")
+				cr = reflect.NewAt(cr.Type(), unsafe.Pointer(cr.UnsafeAddr())).Elem()
+				cr.Set(reflect.ValueOf(&mockConn{}))
+				config := localService.Config
+				err = localService.doSend(client, "Test message", config)
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+				gomega.Expect(buf.String()).
+					To(gomega.ContainSubstring("Warning: Failed to close SMTP client connection: mock close error"))
 			})
 			ginkgo.It("should fail when context is canceled during connection", func() {
 				ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
Office 365 SMTP servers send malformed binary responses to QUIT commands, causing Shoutrrr to incorrectly report successful email deliveries as failed. This fix adds graceful error handling to ignore these harmless session closure errors while preserving proper error reporting for actual delivery failures.

## Problem

SMTP servers like Office 365 send malformed binary responses (e.g., `\x00\x00\x00\x1a\x00\x00\x00`) to QUIT commands during session closure. The current Shoutrrr implementation treats any QUIT error as a critical failure, causing successful email deliveries to be marked as failed. This results in false negative notifications despite emails being delivered successfully.

## Solution

Add targeted error filtering in the SMTP `doSend()` method to detect "short response" errors during QUIT commands. These errors are logged as warnings instead of failing the entire send operation, ensuring successful deliveries are not incorrectly reported as failures. The fix maintains backward compatibility and proper error handling for legitimate delivery issues.

## Changes

- **pkg/services/email/smtp/smtp.go**: Added conditional check for "short response" errors during QUIT command execution, logging warnings instead of failing operations
- **pkg/services/email/smtp/smtp_test.go**: Added unit test to verify graceful handling of "short response" errors during session closure


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email send robustness: short/partial SMTP QUIT responses are treated as non-fatal (logged as warnings) and connection-close errors during cleanup no longer fail the send flow—these are logged and ignored.

* **Tests**
  * Added tests verifying short QUIT responses are ignored with a warning and that cleanup/close failures produce a warning without failing the send.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->