### PR TITLE
docs: update Docker image tags from latest-dev to nightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Install the latest release binary to `$HOME/go/bin` (ensure it's in your `PATH`)
   ```
 
 > [!Note]
-> Tags: `latest` (stable), `vX.Y.Z` (specific version), `latest-dev` (development), platform-specific (e.g., `amd64-latest`).
+> Tags: `latest` (stable), `vX.Y.Z` (specific version), `nightly` (development), platform-specific (e.g., `amd64-nightly`).
 
 ### Go Package
 

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -51,7 +51,7 @@ Shoutrrr provides lightweight Docker images based on Alpine Linux, supporting mu
 
     - **Repository**: <https://hub.docker.com/r/nickfedor/shoutrrr>
     - **Image Reference**: `nickfedor/shoutrrr`
-    - **Tags**: `latest`, `vX.Y.Z` (e.g., `v0.8.0`), `latest-dev`, platform-specific (e.g., `amd64-latest`)
+    - **Tags**: `latest`, `vX.Y.Z` (e.g., `v0.8.0`), `nightly`, platform-specific (e.g., `amd64-nightly`)
 
 === "GitHub Container Registry"
 
@@ -61,10 +61,10 @@ Shoutrrr provides lightweight Docker images based on Alpine Linux, supporting mu
 
     - **Repository**: <https://github.com/nicholas-fedor/shoutrrr/pkgs/container/shoutrrr>
     - **Image Reference**: `ghcr.io/nicholas-fedor/shoutrrr`
-    - **Tags**: `latest`, `vX.Y.Z` (e.g., `v0.8.0`), `latest-dev`, platform-specific (e.g., `arm64v8-latest`)
+    - **Tags**: `latest`, `vX.Y.Z` (e.g., `v0.8.0`), `nightly`, platform-specific (e.g., `arm64v8-nightly`)
 <!-- markdownlint-restore -->
 !!! Note
-    Use `latest` for the latest stable release, versioned tags (e.g., `v0.8.0`) for specific releases, or `latest-dev` for development snapshots. Platform-specific tags are available for targeted deployments.
+    Use `latest` for the latest stable release, versioned tags (e.g., `v0.8.0`) for specific releases, or `nightly` for  a rolling release image. Platform-specific tags are available for targeted deployments.
 
 ## Go Package
 

--- a/docs/usage/docker/index.md
+++ b/docs/usage/docker/index.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Shoutrrr Docker image provides a lightweight containerized version of the Shoutrrr CLI, built on Alpine Linux for minimal size and broad compatibility. It supports all architectures (amd64, arm64, arm/v6, i386, riscv64) and is available on Docker Hub (`nickfedor/shoutrrr`) and GHCR (`ghcr.io/nicholas-fedor/shoutrrr`). Tags include `latest` (stable production), versioned tags (e.g., `v0.8.0`), and `latest-dev` (development snapshots).
+The Shoutrrr Docker image provides a lightweight containerized version of the Shoutrrr CLI. It supports all architectures (amd64, arm64, arm/v6, i386, riscv64) and is available on Docker Hub (`nickfedor/shoutrrr`) and GHCR (`ghcr.io/nicholas-fedor/shoutrrr`). Tags include `latest` (stable production), versioned tags (e.g., `v0.8.0`), and `nightly` (rolling release).
 
 ## Usage
 
@@ -22,12 +22,12 @@ Run Shoutrrr CLI commands inside the container using `docker run`.
 
 The entrypoint is `/shoutrrr`, so commands like `send`, `generate`, `verify` work directly.
 
-| Tag Examples          | Description                                      |
-|-----------------------|--------------------------------------------------|
-| `latest`              | Latest stable release.                           |
-| `vX.Y.Z`              | Specific version (e.g., `v0.8.0`).               |
-| `latest-dev`          | Latest development snapshot.                     |
-| `amd64-latest`        | Platform-specific (e.g., amd64, arm64v8).        |
+| Tag Examples   | Description                               |
+|----------------|-------------------------------------------|
+| `latest`       | Latest stable release.                    |
+| `vX.Y.Z`       | Specific version (e.g., `v0.8.0`).        |
+| `nightly`      | Latest rolling release.                   |
+| `amd64-latest` | Platform-specific (e.g., amd64, arm64v8). |
 
 !!! Note
     The image includes CA certificates and timezone data. No volumes are required by default, but mount if needed for custom configs or stdin input. Environment variables can override flags (e.g., `SHOUTRRR_URL` for `--url`).


### PR DESCRIPTION
This updates the documentation to correspond with the change from `latest-dev` image tags to rolling release `nightly` image tags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker image tag references across installation and usage documentation, replacing `latest-dev` with `nightly` as the rolling release image tag.
  * Updated tag guidance for both Docker Hub and GitHub Container Registry registries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->