### PR TITLE
ci(tests): simplify package filtering with POSIX-compatible syntax

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,12 +53,12 @@ jobs:
       - name: Run Tests
         shell: bash
         run: |
-          readarray -t packages < <(go list ./... | grep -vE '/testing/e2e(/|$)')
-          if [ ${#packages[@]} -eq 0 ]; then
+          packages=$(go list ./... | grep -vE '/testing/e2e(/|$)')
+          if [ -z "$packages" ]; then
             echo "No packages to test after filtering"
             exit 0
           fi
-          go test -v -coverprofile coverage.out -covermode atomic "${packages[@]}"
+          go test -v -coverprofile coverage.out -covermode atomic $packages
 
       - name: Upload Coverage Report to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0


### PR DESCRIPTION
This reverts a change to the unit testing workflow to ensure cross-platform compliance.

- Replace bash-specific readarray with portable command substitution
- Use simple variable instead of array for test package list
- Streamline conditional check for empty package list