### PR TITLE
ci(release-nightly): add FORCE_RELEASE input to bypass change detection

### DIFF
--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -8,6 +8,11 @@ on:
         required: false
         default: false
         type: boolean
+      FORCE_RELEASE:
+        description: "Skip change detection and force the release"
+        required: false
+        default: false
+        type: boolean
   schedule:
     - cron: "0 0 * * *"
 
@@ -17,6 +22,7 @@ permissions:
 jobs:
   check_changes:
     name: Check for Code Changes
+    if: ${{ inputs.FORCE_RELEASE != true }}
     runs-on: ubuntu-latest
     permissions:
       actions: read # For querying previous workflow runs via API
@@ -70,7 +76,7 @@ jobs:
   test:
     name: Run Tests
     needs: [check_changes]
-    if: ${{ needs.check_changes.outputs.has-changes == 'true' }}
+    if: ${{ needs.check_changes.outputs.has-changes == 'true' || inputs.FORCE_RELEASE == 'true' }}
     uses: ./.github/workflows/test.yaml
     permissions:
       contents: read # For code checkout
@@ -78,7 +84,7 @@ jobs:
   build:
     name: Run Build
     needs: [check_changes, test]
-    if: ${{ needs.check_changes.outputs.has-changes == 'true' }}
+    if: ${{ needs.check_changes.outputs.has-changes == 'true' || inputs.FORCE_RELEASE == 'true' }}
     uses: ./.github/workflows/build.yaml
     permissions:
       contents: write # For code checkout and uploading release artifacts


### PR DESCRIPTION
- add FORCE_RELEASE workflow input to skip change detection
- skip check_changes job when force release is triggered
- allow test and build jobs to run on forced releases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced nightly release workflow with manual override capability for release execution, enabling forced releases independent of standard change detection when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->