### PR TITLE
ci(test): update Go version to 1.26.x

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version:
-          - 1.25.x
+          - 1.26.x
         platform:
           - macos-latest
           - windows-2025


### PR DESCRIPTION
- bump go-version matrix from 1.25.x to 1.26.x in test workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing infrastructure to use Go 1.26.x in CI/CD pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->