### PR TITLE
ci(test): resolve malformed import path in test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,12 +51,7 @@ jobs:
       - name: Run Tests
         shell: bash
         run: |
-          packages=$(go list ./... | grep -vE '/testing/e2e(/|$)')
-          if [ -z "$packages" ]; then
-            echo "No packages to test after filtering"
-            exit 0
-          fi
-          go test -v -coverprofile coverage.out -covermode atomic "$packages"
+          go test -v -coverprofile coverage.out -covermode atomic $(go list ./... | grep -vE '/testing/e2e(/|$)')
 
       - name: Upload Coverage Report to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0


### PR DESCRIPTION
Fixed malformed import path error in `.github/workflows/test.yaml` that caused the nightly release workflow to fail during the test step.

## Problem

The test workflow stored the output of `go list ./...` (newline-separated package paths) in a shell variable `$packages`. When this variable was expanded in `go test "$packages"`, the newlines were interpreted as part of the import path string rather than as argument separators, resulting in a "malformed import path" error.

## Solution

Replaced the intermediate variable with direct command substitution `$(go list ./... | grep -vE '/testing/e2e(/|$)')` which properly expands each package as a separate argument to `go test`.

## Changes

- Removed intermediate `packages` variable and empty check logic
- Used direct command substitution for cleaner argument expansion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified test execution workflow for improved CI/CD efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->