### PR TITLE
ci(test): resolve package list splitting in test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Run Tests
         shell: bash
         run: |
-          go test -v -coverprofile coverage.out -covermode atomic "$(go list ./... | grep -vE '/testing/e2e(/|$)')"
+          go list ./... | grep -vE '/testing/e2e(/|$)' | xargs go test -v -coverprofile coverage.out -covermode atomic
 
       - name: Upload Coverage Report to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0


### PR DESCRIPTION
Pipe go list output through xargs instead of quoted subshell

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the continuous integration testing workflow with an improved command pipeline for better efficiency. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->