### PR TITLE
fix(matrix): send valid JSON body in joinRoom and validate room input

### DIFF
--- a/build/golangci-lint/golangci.yaml
+++ b/build/golangci-lint/golangci.yaml
@@ -329,35 +329,46 @@ linters:
     goconst:
       # Minimal length of string constant.
       # Default: 3
-      # min-len: 2
+      min-len: 3
       # Minimum occurrences of constant string count to trigger issue.
       # Default: 3
-      # min-occurrences: 2
+      min-occurrences: 5
       # Look for existing constants matching the values.
       # Default: true
-      # match-constant: false
+      match-constant: false
       # Search also for duplicated numbers.
       # Default: false
-      numbers: true
+      numbers: false
       # Minimum value, only works with `goconst.numbers`.
       # Default: 3
-      # min: 2
+      min: 3
       # Maximum value, only works with `goconst.numbers`.
       # Default: 3
-      # max: 2
+      max: 3
       # Ignore when constant is not used as function argument.
       # Default: true
-      # ignore-calls: false
+      ignore-calls: false
       # Exclude strings matching the given regular expression.
       # Default: ""
-      # ignore-string-values:
-      #   - "foo.+"
+      ignore-string-values:
+        - ""
       # Detects constants with identical values.
       # Default: false
       find-duplicates: true
       # Evaluates of constant expressions like Prefix + "suffix".
       # Default: false
-      eval-const-expressions: true
+      eval-const-expressions: false
+      # Ignore strings from test files.
+      # Default: false
+      ignore-tests: true
+      # Ignore string literals in calls to these functions
+      # Default: empty list
+      ignore-functions:
+        - "log.*"
+        - "slog.*"
+        - "fmt.Printf"
+        - "fmt.Errorf"
+        - "errors.New"
 
     ####################################################################################################
     # https://golangci-lint.run/docs/linters/configuration/#gocritic

--- a/pkg/services/chat/matrix/matrix_client.go
+++ b/pkg/services/chat/matrix/matrix_client.go
@@ -264,7 +264,7 @@ func (c *client) joinRoom(ctx context.Context, room string) (string, error) {
 	err := c.apiPost(
 		ctx,
 		fmt.Sprintf(apiRoomJoin, room),
-		nil,
+		&struct{}{},
 		&resRoom,
 	)
 	if err != nil {
@@ -420,23 +420,34 @@ func (c *client) sendToExplicitRooms(ctx context.Context, rooms []string, messag
 	var errs []error
 
 	for _, room := range rooms {
-		c.logf("Sending message to '%v'...\n", room)
-
-		roomID, err := c.joinRoom(ctx, room)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("error joining room %v: %w", roomID, err))
+		room = strings.TrimSpace(room)
+		if room == "" {
+			errs = append(errs, fmt.Errorf("%w", ErrEmptyRoom))
 
 			continue
 		}
 
-		if room != roomID {
-			c.logf("Resolved room alias '%v' to ID '%v'", room, roomID)
+		c.logf("Sending message to '%v'...\n", room)
+
+		if !strings.HasPrefix(room, "!") {
+			roomID, err := c.joinRoom(ctx, room)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("error joining room %v: %w", room, err))
+
+				continue
+			}
+
+			if room != roomID {
+				c.logf("Resolved room alias '%v' to ID '%v'", room, roomID)
+			}
+
+			room = roomID
 		}
 
-		if err := c.sendMessageToRoom(ctx, message, roomID); err != nil {
+		if err := c.sendMessageToRoom(ctx, message, room); err != nil {
 			errs = append(
 				errs,
-				fmt.Errorf("failed to send message to room '%v': %w", roomID, err),
+				fmt.Errorf("failed to send message to room '%v': %w", room, err),
 			)
 		}
 	}

--- a/pkg/services/chat/matrix/matrix_client_test.go
+++ b/pkg/services/chat/matrix/matrix_client_test.go
@@ -296,6 +296,34 @@ var _ = ginkgo.Describe("client", func() {
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(roomID).To(gomega.Equal("!joinedroom:matrix.example.com"))
 		})
+
+		ginkgo.It("should send a valid JSON object body, not null", func() {
+			mockHTTPClient := mocks.NewMockHTTPClient(ginkgo.GinkgoT())
+			mockHTTPClient.On("Do", mock.MatchedBy(func(req *http.Request) bool {
+				body, err := io.ReadAll(req.Body)
+				if err != nil {
+					return false
+				}
+
+				return string(body) == "{}"
+			})).Return(&http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader([]byte(`{"room_id":"!joinedroom:matrix.example.com"}`))),
+			}, nil)
+
+			c := &client{
+				apiURL: url.URL{
+					Scheme: "https",
+					Host:   "matrix.example.com",
+				},
+				httpClient: mockHTTPClient,
+				logger:     &testLogger{},
+			}
+
+			roomID, err := c.joinRoom(context.Background(), "#test:matrix.example.com")
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(roomID).To(gomega.Equal("!joinedroom:matrix.example.com"))
+		})
 	})
 
 	ginkgo.Describe("logf", func() {
@@ -575,6 +603,108 @@ var _ = ginkgo.Describe("client", func() {
 
 			errs := c.sendToExplicitRooms(context.Background(), []string{"#room:matrix.example.com"}, "test message")
 			gomega.Expect(errs).To(gomega.HaveLen(1))
+		})
+
+		ginkgo.It("should skip joinRoom when room ID starts with !", func() {
+			mockHTTPClient := mocks.NewMockHTTPClient(ginkgo.GinkgoT())
+			// Only one call expected: sendMessageToRoom (no joinRoom)
+			mockHTTPClient.On("Do", mock.AnythingOfType("*http.Request")).Return(&http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader([]byte(`{"event_id":"$eventid"}`))),
+			}, nil).Once()
+
+			c := &client{
+				apiURL: url.URL{
+					Scheme: "https",
+					Host:   "matrix.example.com",
+				},
+				httpClient: mockHTTPClient,
+				logger:     &testLogger{},
+			}
+
+			errs := c.sendToExplicitRooms(context.Background(), []string{"!roomid:matrix.example.com"}, "test message")
+			gomega.Expect(errs).To(gomega.BeEmpty())
+			mockHTTPClient.AssertNumberOfCalls(ginkgo.GinkgoT(), "Do", 1)
+		})
+
+		ginkgo.It("should handle mixed room IDs and aliases", func() {
+			mockHTTPClient := mocks.NewMockHTTPClient(ginkgo.GinkgoT())
+			// First call: joinRoom for alias
+			mockHTTPClient.On("Do", mock.AnythingOfType("*http.Request")).Return(&http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader([]byte(`{"room_id":"!roomid:matrix.example.com"}`))),
+			}, nil).Once()
+			// Second call: sendMessageToRoom for alias-resolved room
+			mockHTTPClient.On("Do", mock.AnythingOfType("*http.Request")).Return(&http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader([]byte(`{"event_id":"$eventid1"}`))),
+			}, nil).Once()
+			// Third call: sendMessageToRoom for room ID (no joinRoom needed)
+			mockHTTPClient.On("Do", mock.AnythingOfType("*http.Request")).Return(&http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader([]byte(`{"event_id":"$eventid2"}`))),
+			}, nil).Once()
+
+			c := &client{
+				apiURL: url.URL{
+					Scheme: "https",
+					Host:   "matrix.example.com",
+				},
+				httpClient: mockHTTPClient,
+				logger:     &testLogger{},
+			}
+
+			errs := c.sendToExplicitRooms(context.Background(), []string{"#room:matrix.example.com", "!otherroom:matrix.example.com"}, "test message")
+			gomega.Expect(errs).To(gomega.BeEmpty())
+			mockHTTPClient.AssertNumberOfCalls(ginkgo.GinkgoT(), "Do", 3)
+		})
+
+		ginkgo.It("should return error for empty room value", func() {
+			c := &client{
+				apiURL: url.URL{
+					Scheme: "https",
+					Host:   "matrix.example.com",
+				},
+				logger: &testLogger{},
+			}
+
+			errs := c.sendToExplicitRooms(context.Background(), []string{""}, "test message")
+			gomega.Expect(errs).To(gomega.HaveLen(1))
+			gomega.Expect(errors.Is(errs[0], ErrEmptyRoom)).To(gomega.BeTrue())
+		})
+
+		ginkgo.It("should return error for whitespace-only room value", func() {
+			c := &client{
+				apiURL: url.URL{
+					Scheme: "https",
+					Host:   "matrix.example.com",
+				},
+				logger: &testLogger{},
+			}
+
+			errs := c.sendToExplicitRooms(context.Background(), []string{"   "}, "test message")
+			gomega.Expect(errs).To(gomega.HaveLen(1))
+			gomega.Expect(errors.Is(errs[0], ErrEmptyRoom)).To(gomega.BeTrue())
+		})
+
+		ginkgo.It("should trim whitespace from room value before processing", func() {
+			mockHTTPClient := mocks.NewMockHTTPClient(ginkgo.GinkgoT())
+			mockHTTPClient.On("Do", mock.AnythingOfType("*http.Request")).Return(&http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader([]byte(`{"event_id":"$eventid"}`))),
+			}, nil).Once()
+
+			c := &client{
+				apiURL: url.URL{
+					Scheme: "https",
+					Host:   "matrix.example.com",
+				},
+				httpClient: mockHTTPClient,
+				logger:     &testLogger{},
+			}
+
+			errs := c.sendToExplicitRooms(context.Background(), []string{"  !roomid:matrix.example.com  "}, "test message")
+			gomega.Expect(errs).To(gomega.BeEmpty())
 		})
 	})
 

--- a/pkg/services/chat/matrix/matrix_errors.go
+++ b/pkg/services/chat/matrix/matrix_errors.go
@@ -27,4 +27,7 @@ var (
 	// ErrUnexpectedStatus is returned when the Matrix API returns an HTTP
 	// status code that was not expected by the client.
 	ErrUnexpectedStatus = errors.New("unexpected HTTP status")
+
+	// ErrEmptyRoom is returned when a room value is empty or contains only whitespace.
+	ErrEmptyRoom = errors.New("room value is empty")
 )

--- a/pkg/services/push/mqtt/mqtt_service.go
+++ b/pkg/services/push/mqtt/mqtt_service.go
@@ -301,7 +301,6 @@ func (s *Service) getCancel() context.CancelFunc {
 		// Create a cancellable context for managing the connection lifecycle.
 		// Both ctx and cancel are stored so that cancel() can terminate
 		// operations using this context.
-		//nolint:gosec // G118: cancel is called in Close() method
 		s.ctx, s.cancel = context.WithTimeout(
 			context.Background(),
 			publishTimeout*time.Second,

--- a/shoutrrr/cmd/generate/generate.go
+++ b/shoutrrr/cmd/generate/generate.go
@@ -19,6 +19,9 @@ import (
 // MaximumNArgs defines the maximum number of positional arguments allowed.
 const MaximumNArgs = 2
 
+// redactedStr represents the placeholder string for masked text values.
+const redactedStr = "REDACTED"
+
 var (
 	// ErrNoServiceSpecified indicates that no service was provided for URL generation.
 	ErrNoServiceSpecified = errors.New("no service specified")
@@ -237,7 +240,7 @@ func maskSensitiveURL(serviceSchema, urlStr string) string {
 
 	switch serviceSchema {
 	case "discord", "slack", "teams":
-		maskUser(parsedURL, "REDACTED")
+		maskUser(parsedURL, redactedStr)
 	case "smtp":
 		maskSMTPUser(parsedURL)
 	case "pushover":
@@ -268,7 +271,7 @@ func maskUser(parsedURL *url.URL, placeholder string) {
 //   - parsedURL: The SMTP URL to modify.
 func maskSMTPUser(parsedURL *url.URL) {
 	if parsedURL.User != nil {
-		parsedURL.User = url.UserPassword(parsedURL.User.Username(), "REDACTED")
+		parsedURL.User = url.UserPassword(parsedURL.User.Username(), redactedStr)
 	}
 }
 
@@ -279,11 +282,11 @@ func maskSMTPUser(parsedURL *url.URL) {
 func maskPushoverQuery(parsedURL *url.URL) {
 	queryParams := parsedURL.Query()
 	if queryParams.Get("token") != "" {
-		queryParams.Set("token", "REDACTED")
+		queryParams.Set("token", redactedStr)
 	}
 
 	if queryParams.Get("user") != "" {
-		queryParams.Set("user", "REDACTED")
+		queryParams.Set("user", redactedStr)
 	}
 
 	parsedURL.RawQuery = queryParams.Encode()
@@ -296,7 +299,7 @@ func maskPushoverQuery(parsedURL *url.URL) {
 func maskGotifyQuery(parsedURL *url.URL) {
 	queryParams := parsedURL.Query()
 	if queryParams.Get("token") != "" {
-		queryParams.Set("token", "REDACTED")
+		queryParams.Set("token", redactedStr)
 	}
 
 	parsedURL.RawQuery = queryParams.Encode()
@@ -307,11 +310,11 @@ func maskGotifyQuery(parsedURL *url.URL) {
 // Parameters:
 //   - parsedURL: The URL to modify.
 func maskGeneric(parsedURL *url.URL) {
-	maskUser(parsedURL, "REDACTED")
+	maskUser(parsedURL, redactedStr)
 
 	queryParams := parsedURL.Query()
 	for key := range queryParams {
-		queryParams.Set(key, "REDACTED")
+		queryParams.Set(key, redactedStr)
 	}
 
 	parsedURL.RawQuery = queryParams.Encode()

--- a/shoutrrr/cmd/generate/generate_test.go
+++ b/shoutrrr/cmd/generate/generate_test.go
@@ -151,13 +151,13 @@ func Test_maskUser(t *testing.T) {
 		{
 			name:        "masks user with placeholder",
 			urlStr:      "https://token@host/path",
-			placeholder: "REDACTED",
-			wantUser:    "REDACTED",
+			placeholder: redactedStr,
+			wantUser:    redactedStr,
 		},
 		{
 			name:        "empty user remains nil",
 			urlStr:      "https://host/path",
-			placeholder: "REDACTED",
+			placeholder: redactedStr,
 			wantUser:    "",
 		},
 	}
@@ -194,13 +194,13 @@ func Test_maskSMTPUser(t *testing.T) {
 			name:     "masks password preserving username",
 			urlStr:   "smtp://user:pass@host:587",
 			wantUser: "user",
-			wantPass: "REDACTED",
+			wantPass: redactedStr,
 		},
 		{
 			name:     "user without password gets redacted password",
 			urlStr:   "smtp://user@host:587",
 			wantUser: "user",
-			wantPass: "REDACTED",
+			wantPass: redactedStr,
 		},
 		{
 			name:     "nil user remains nil",
@@ -247,13 +247,13 @@ func Test_maskPushoverQuery(t *testing.T) {
 		{
 			name:     "masks token and user",
 			urlStr:   "pushover://?token=abc&user=def",
-			wantTok:  "REDACTED",
-			wantUser: "REDACTED",
+			wantTok:  redactedStr,
+			wantUser: redactedStr,
 		},
 		{
 			name:     "masks only token",
 			urlStr:   "pushover://?token=abc",
-			wantTok:  "REDACTED",
+			wantTok:  redactedStr,
 			wantUser: "",
 		},
 		{
@@ -302,7 +302,7 @@ func Test_maskGotifyQuery(t *testing.T) {
 		{
 			name:    "masks token",
 			urlStr:  "gotify://?token=secret",
-			wantTok: "REDACTED",
+			wantTok: redactedStr,
 		},
 		{
 			name:    "leaves other params unchanged",
@@ -345,23 +345,23 @@ func Test_maskGeneric(t *testing.T) {
 		{
 			name:     "masks user and all query params",
 			urlStr:   "https://user:pass@host?a=1&b=2",
-			wantUser: "REDACTED",
+			wantUser: redactedStr,
 			wantParams: map[string]string{
-				"a": "REDACTED",
-				"b": "REDACTED",
+				"a": redactedStr,
+				"b": redactedStr,
 			},
 			wantQueryLen: 2,
 		},
 		{
 			name:     "masks only user when no query params",
 			urlStr:   "https://user:pass@host",
-			wantUser: "REDACTED",
+			wantUser: redactedStr,
 		},
 		{
 			name:         "nil user with query params",
 			urlStr:       "https://host?a=1",
 			wantUser:     "",
-			wantParams:   map[string]string{"a": "REDACTED"},
+			wantParams:   map[string]string{"a": redactedStr},
 			wantQueryLen: 1,
 		},
 	}


### PR DESCRIPTION
This PR primarily addresses Shoutrrr's Matrix service integration by improving Matrix spec compliance when joining rooms. It also implements a minor update to the Golangci-lint Gosec linter configuration and minor refactoring of repeated strings to a constant.

## Problem

Shoutrrr was sending a null request body to the Matrix /join endpoint. The spec requires a JSON object, so the body needs to be an empty object instead of null. Room IDs (starting with !) were also being passed to joinRoom unnecessarily, and empty or whitespace-only room strings weren't validated before use.

## Solution

Changed joinRoom to send an empty JSON object as the POST body. Room IDs starting with ! now skip the join step entirely. Room values are trimmed and validated as non-empty before any processing.

## Changes

- Fixed joinRoom POST body from nil to {} to comply with the Matrix spec
- Skip joinRoom in sendToExplicitRooms when room starts with !
- Trim whitespace and return ErrEmptyRoom for empty room values
- Added unit tests to help provide coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Matrix chat room handling with better validation and support for different room identifier formats.
  * Added validation to reject empty or whitespace-only room values.

* **Tests**
  * Enhanced test coverage for Matrix chat room operations and edge cases.

* **Chores**
  * Code consolidation and linting configuration updates for improved maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nicholas-fedor/shoutrrr/pull/878?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->