### PR TITLE
feat(teams): migrate from Office 365 Connectors to Power Automate workflow webhooks

### DIFF
--- a/docs/services/chat/teams/index.md
+++ b/docs/services/chat/teams/index.md
@@ -1,6 +1,6 @@
 # Teams
 
-!!! attention "Office 365 Connector Retirement"
+!!! Attention "Office 365 Connector Retirement"
     As noted in Microsoft's [update](https://devblogs.microsoft.com/microsoft365dev/retirement-of-office-365-connectors-within-microsoft-teams/),
     Office 365 Connectors within Microsoft Teams have been retired.
 
@@ -19,7 +19,7 @@ teams://?host=<Power Automate workflow URL>[&color=<hex color>][&title=<title>]
 Where:
 
 - `host`: The full Power Automate workflow incoming webhook URL (required).
-- `color` *(optional)*: Reserved for future use.
+- `color` *(optional)*: Hex color code for the title text (e.g., `FF0000` for red).
 - `title` *(optional)*: Title displayed as a bold header in the Adaptive Card.
 
 --8<-- "docs/services/chat/teams/config.md"
@@ -35,11 +35,15 @@ For more information, see the
 
 ## Example
 
-```text
-# Power Automate workflow webhook URL:
-https://prod-00.westus.logic.azure.com:443/workflows/abc123/triggers/manual/paths/invoke?api-version=2016-06-00&sp=/triggers/manual/run&sv=1.0&sig=XXXXXXXX
+Teams/Power Automate workflow webhook URL:
 
-# Shoutrrr URL:
+```text
+https://prod-00.westus.logic.azure.com:443/workflows/abc123/triggers/manual/paths/invoke?   api-version=2016-06-00&sp=/triggers/manual/run&sv=1.0&sig=XXXXXXXX
+```
+
+Shoutrrr URL:
+
+```text
 teams://?host=https%3A%2F%2Fprod-00.westus.logic.azure.com%3A443%2Fworkflows%2Fabc123%2Ftriggers%2Fmanual%2Fpaths%2Finvoke%3Fapi-version%3D2016-06-00%26sp%3D%2Ftriggers%2Fmanual%2Frun%26sv%3D1.0%26sig%3DXXXXXXXX&title=Alert
 ```
 

--- a/docs/services/chat/teams/index.md
+++ b/docs/services/chat/teams/index.md
@@ -1,69 +1,49 @@
 # Teams
 
-!!! attention "New webhook URL format only"
-    Shoutrrr now only supports the new Teams webhook URL format with an
-    organization-specific domain.
+!!! attention "Office 365 Connector Retirement"
+    As noted in Microsoft's [update](https://devblogs.microsoft.com/microsoft365dev/retirement-of-office-365-connectors-within-microsoft-teams/),
+    Office 365 Connectors within Microsoft Teams have been retired.
 
-    You must specify your organization domain using:
+    The legacy `webhook.office.com` webhook URLs and MessageCard format are no longer functional.
 
-    ```text
-    ?host=example.webhook.office.com
-    ```
-    Where `example` is your organization's short name.
-
-    Legacy webhook formats (e.g., `outlook.office.com`) are no longer supported.
+    Shoutrrr now uses Power Automate workflow incoming webhooks exclusively.
+    Existing configurations using the old URL format must be migrated to the new
+    `teams://?host=<workflow URL>` format documented below.
 
 ## URL Format
 
-```
-teams://group@tenant/altId/groupOwner/extraId?host=organization.webhook.office.com[&color=color][&title=title]
+```text
+teams://?host=<Power Automate workflow URL>[&color=<hex color>][&title=<title>]
 ```
 
 Where:
 
-- `group`: The first UUID component from the webhook URL.
-- `tenant`: The second UUID component from the webhook URL.
-- `altId`: The third component (hex string) from the webhook URL.
-- `groupOwner`: The fourth UUID component from the webhook URL.
-- `extraId`: The fifth component at the end of the webhook URL.
-- `organization`: Your organization name for the webhook domain (required).
-- `color`: Optional hex color code for the message card (e.g., `FF0000` for red).
-- `title`: Optional title for the message card.
+- `host`: The full Power Automate workflow incoming webhook URL (required).
+- `color` *(optional)*: Reserved for future use.
+- `title` *(optional)*: Title displayed as a bold header in the Adaptive Card.
 
 --8<-- "docs/services/chat/teams/config.md"
 
 ## Setting up a webhook
 
-To use the Microsoft Teams notification service, you need to set up a custom
-incoming webhook. Follow the instructions in [this Microsoft guide](https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook#create-an-incoming-webhook).
+To use the Microsoft Teams notification service with Power Automate, create a new
+workflow in Power Automate and add the "When a Teams webhook request is received"
+trigger. Copy the generated webhook URL from the trigger.
 
-## Extracting the token
-
-The token is extracted from your webhook URL:
-
-<pre><code>https://<b>&lt;organization&gt;</b>.webhook.office.com/webhookb2/<b>&lt;group&gt;</b>@<b>&lt;tenant&gt;</b>/IncomingWebhook/<b>&lt;altId&gt;</b>/<b>&lt;groupOwner&gt;</b>/<b>&lt;extraId&gt;</b></code></pre>
-
-!!! note "Important components"
-    All parts of the webhook URL are required:
-
-    - `organization`: Your organization name (e.g., `contoso`).
-    - `group`: First UUID component.
-    - `tenant`: Second UUID component.
-    - `altId`: Third component (hex string).
-    - `groupOwner`: Fourth UUID component.
-    - `extraId`: Fifth component.
+For more information, see the
+[Microsoft Learn documentation](https://learn.microsoft.com/en-us/connectors/teams/#microsoft-teams-webhook).
 
 ## Example
 
-```
-# Original webhook URL:
-https://contoso.webhook.office.com/webhookb2/11111111-4444-4444-8444-cccccccccccc@22222222-4444-4444-8444-cccccccccccc/IncomingWebhook/33333333012222222222333333333344/44444444-4444-4444-8444-cccccccccccc/V2ESyij_gAljSoUQHvZoZYzlpAoAXExyOl26dlf1xHEx05
+```text
+# Power Automate workflow webhook URL:
+https://prod-00.westus.logic.azure.com:443/workflows/abc123/triggers/manual/paths/invoke?api-version=2016-06-00&sp=/triggers/manual/run&sv=1.0&sig=XXXXXXXX
 
 # Shoutrrr URL:
-teams://11111111-4444-4444-8444-cccccccccccc@22222222-4444-4444-8444-cccccccccccc/33333333012222222222333333333344/44444444-4444-4444-8444-cccccccccccc/V2ESyij_gAljSoUQHvZoZYzlpAoAXExyOl26dlf1xHEx05?host=contoso.webhook.office.com&color=FF0000&title=Alert
+teams://?host=https%3A%2F%2Fprod-00.westus.logic.azure.com%3A443%2Fworkflows%2Fabc123%2Ftriggers%2Fmanual%2Fpaths%2Finvoke%3Fapi-version%3D2016-06-00%26sp%3D%2Ftriggers%2Fmanual%2Frun%26sv%3D1.0%26sig%3DXXXXXXXX&title=Alert
 ```
 
 In this example:
 
-- `color=FF0000` sets a red theme.
-- `title=Alert` adds a custom title to the message card.
+- The `host` param is the full Power Automate workflow webhook URL (percent-encoded).
+- `title=Alert` adds a bold title header to the Adaptive Card.

--- a/docs/services/chat/teams/index.md
+++ b/docs/services/chat/teams/index.md
@@ -19,7 +19,7 @@ teams://?host=<Power Automate workflow URL>[&color=<hex color>][&title=<title>]
 Where:
 
 - `host`: The full Power Automate workflow incoming webhook URL (required).
-- `color` *(optional)*: Hex color code for the title text (e.g., `FF0000` for red).
+- `color` *(optional)*: Title text color. Accepts Adaptive Card color names (`accent`, `good`, `warning`, `attention`, `dark`, `light`, `default`) or common color names (`red`, `green`, `blue`, `yellow`, `orange`).
 - `title` *(optional)*: Title displayed as a bold header in the Adaptive Card.
 
 --8<-- "docs/services/chat/teams/config.md"
@@ -38,7 +38,7 @@ For more information, see the
 Teams/Power Automate workflow webhook URL:
 
 ```text
-https://prod-00.westus.logic.azure.com:443/workflows/abc123/triggers/manual/paths/invoke?   api-version=2016-06-00&sp=/triggers/manual/run&sv=1.0&sig=XXXXXXXX
+https://prod-00.westus.logic.azure.com:443/workflows/abc123/triggers/manual/paths/invoke?api-version=2016-06-00&sp=/triggers/manual/run&sv=1.0&sig=XXXXXXXX
 ```
 
 Shoutrrr URL:

--- a/docs/services/overview.md
+++ b/docs/services/overview.md
@@ -15,7 +15,7 @@ Click on the service for a more thorough explanation.
 | [Rocketchat](./chat/rocketchat/index.md)  | *rocketchat://[__`username`__@]__`rocketchat-host`__/__`token`__[/__`channel`&#124;`@recipient`__]*                         |
 | [Signal](./chat/signal/index.md)          | *signal://[__`user`__[:__`password`__]@]__`host`__[:__`port`__]/__`source_phone`__/__`recipient1`__[,__`recipient2`__,...]* |
 | [Slack](./chat/slack/index.md)            | *slack://[__`botname`__@]__`token-a`__/__`token-b`__/__`token-c`__*                                                         |
-| [Teams](./chat/teams/index.md)            | *teams://__`group`__@__`tenant`__/__`altId`__/__`groupOwner`__?host=__`organization`__.webhook.office.com*                  |
+| [Teams](./chat/teams/index.md)            | *teams://?host=__`Power Automate workflow URL`__*                                                                           |
 | [Telegram](./chat/telegram/index.md)      | *telegram://__`token`__@telegram?chats=__`@channel-1`__[,__`chat-id-1`__,...]*                                              |
 | [WeCom](./chat/wecom/index.md)            | *wecom://__`key`__*                                                                                                         |
 | [Zulip Chat](./chat/zulip/index.md)       | *zulip://__`bot-mail`__:__`bot-key`__@__`zulip-domain`__/?stream=__`name-or-id`__&topic=__`name`__*                         |

--- a/pkg/router/router_suite_test.go
+++ b/pkg/router/router_suite_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	mockCustomURL = "teams+https://publicservice.webhook.office.com/webhookb2/11111111-4444-4444-8444-cccccccccccc@22222222-4444-4444-8444-cccccccccccc/IncomingWebhook/33333333012222222222333333333344/44444444-4444-4444-8444-cccccccccccc/V2ESyij_gAljSoUQHvZoZYzlpAoAXExyOl26dlf1xHEx05?host=publicservice.webhook.office.com"
+	mockCustomURL = "generic+https://example.com/webhook"
 )
 
 var sr ServiceRouter

--- a/pkg/services/chat/teams/doc.go
+++ b/pkg/services/chat/teams/doc.go
@@ -1,34 +1,20 @@
-// Package teams provides a notification service for sending messages to Microsoft Teams via webhooks.
-//
-// This package is part of the shoutrrr notification library and implements the Service interface
-// for delivering notifications to Microsoft Teams using Office 365 connector webhooks.
+// Package teams provides a notification service for sending messages to Microsoft Teams
+// via Power Automate workflow incoming webhooks using the Adaptive Card format.
 //
 // # Service Configuration
 //
-// The Service struct provides the main functionality for sending notifications to Microsoft Teams.
-// It embeds standard.Standard for common service features and supports both URL-based configuration
-// and direct webhook URL parsing.
-//
-// # Configuration Fields
-//
 // The Config struct supports the following settings:
 //
-//   - Group: The Office 365 group name (optional)
-//   - Tenant: The Office 365 tenant ID (optional)
-//   - AltID: The first part of the webhook URL path (optional)
-//   - GroupOwner: The second part of the webhook URL path (optional)
-//   - ExtraID: The third part of the webhook URL path (optional)
-//   - Title: The notification title displayed in Teams (optional)
-//   - Color: The message accent color in hex format (optional)
-//   - Host: The webhook host, typically organization.webhook.office.com (required)
+//   - Host: The full Power Automate workflow webhook URL (required)
+//     Example: https://prod-00.westus.logic.azure.com:443/workflows/{id}/triggers/manual/paths/invoke?api-version=...
+//   - Title: The notification title displayed as a bold header in the card (optional)
+//   - Color: Reserved for future use (optional)
 //
-// # MessageCard Format
+// # Adaptive Card Format
 //
-// Notifications are sent using the Microsoft Teams MessageCard format, which supports:
-//   - Markdown content
-//   - Themed colors for visual distinction
-//   - Section-based layout
-//   - Summary text for notification previews
+// Notifications are sent as Adaptive Cards wrapped in the Power Automate
+// webhook message envelope (type: "message" with attachments array).
+// The message body is rendered as TextBlock elements within the card.
 //
 // # Usage Example
 //
@@ -39,12 +25,6 @@
 //	}
 //	err = service.Send("Your message here", nil)
 //
-// # Webhook URL Parsing
-//
-// The package supports parsing full Microsoft Teams webhook URLs for easier configuration:
-//
-//	teams+https://organization.webhook.office.com/webhookb2/...
-//
-// For more information about Teams connectors, visit:
-// https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/what-are-webhooks-and-connectors
+// For more information about Power Automate workflow webhooks, visit:
+// https://learn.microsoft.com/en-us/connectors/teams/#microsoft-teams-webhook
 package teams

--- a/pkg/services/chat/teams/teams_config.go
+++ b/pkg/services/chat/teams/teams_config.go
@@ -14,9 +14,9 @@ import (
 type Config struct {
 	standard.EnumlessConfig
 
-	Host  string `desc:"The full Power Automate workflow incoming webhook URL"                   key:"host"`
-	Title string `desc:"Title displayed as a bold header in the Adaptive Card"                   key:"title" optional:""`
-	Color string `desc:"Hex color code for the title text and card accent (e.g. FF0000 for red)" key:"color" optional:""`
+	Host  string `desc:"The full Power Automate workflow incoming webhook URL"                        key:"host"`
+	Title string `desc:"Title displayed as a bold header in the Adaptive Card"                        key:"title" optional:""`
+	Color string `desc:"Title text color (accent, good, warning, attention, dark, light, or default)" key:"color" optional:""`
 }
 
 // Scheme is the identifier for the Teams service protocol.

--- a/pkg/services/chat/teams/teams_config.go
+++ b/pkg/services/chat/teams/teams_config.go
@@ -1,10 +1,9 @@
 package teams
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
-	"regexp"
-	"strings"
 
 	"github.com/nicholas-fedor/shoutrrr/pkg/format"
 	"github.com/nicholas-fedor/shoutrrr/pkg/services/standard"
@@ -15,57 +14,19 @@ import (
 type Config struct {
 	standard.EnumlessConfig
 
-	Group      string `optional:"" url:"user"`
-	Tenant     string `optional:"" url:"host"`
-	AltID      string `optional:"" url:"path1"`
-	GroupOwner string `optional:"" url:"path2"`
-	ExtraID    string `optional:"" url:"path3"`
-
+	Host  string `key:"host"  optional:""`
 	Title string `key:"title" optional:""`
 	Color string `key:"color" optional:""`
-	Host  string `key:"host"  optional:""` // Required, no default
 }
 
 // Scheme is the identifier for the Teams service protocol.
 const Scheme = "teams"
-
-// Config constants.
-const (
-	ExpectedOrgMatches = 2 // Full match plus organization domain capture group
-	MinPathComponents  = 3 // Minimum required path components: AltID, GroupOwner, ExtraID
-)
-
-// dummyURL is a placeholder URL used during documentation generation.
-const dummyURL = "teams://dummy@dummy.com"
 
 // GetURL constructs a URL from the Config fields.
 func (c *Config) GetURL() *url.URL {
 	resolver := format.NewPropKeyResolver(c)
 
 	return c.getURL(&resolver)
-}
-
-// SetFromWebhookURL updates the Config from a Teams webhook URL.
-func (c *Config) SetFromWebhookURL(webhookURL string) error {
-	orgPattern := regexp.MustCompile(
-		`https://([a-zA-Z0-9-\.]+)` + WebhookDomain + `/` + Path + `/([0-9a-f\-]{36})@([0-9a-f\-]{36})/` + ProviderName + `/([0-9a-f]{32})/([0-9a-f\-]{36})/([^/]+)`,
-	)
-
-	orgGroups := orgPattern.FindStringSubmatch(webhookURL)
-	if len(orgGroups) != ExpectedComponents {
-		return ErrInvalidWebhookFormat
-	}
-
-	c.Host = orgGroups[1] + ".webhook.office.com"
-
-	parts, err := ParseAndVerifyWebhookURL(webhookURL)
-	if err != nil {
-		return err
-	}
-
-	c.setFromWebhookParts(&parts)
-
-	return nil
 }
 
 // SetURL updates the Config from a URL.
@@ -75,142 +36,31 @@ func (c *Config) SetURL(serviceURL *url.URL) error {
 	return c.setURL(&resolver, serviceURL)
 }
 
-// WebhookParts returns the webhook components as an array.
-func (c *Config) WebhookParts() [5]string {
-	return [5]string{c.Group, c.Tenant, c.AltID, c.GroupOwner, c.ExtraID}
-}
-
-// getURL constructs a URL using the provided resolver.
 func (c *Config) getURL(resolver types.ConfigQueryResolver) *url.URL {
-	if c.Host == "" {
-		return nil
-	}
-
 	return &url.URL{
-		User:     url.User(c.Group),
-		Host:     c.Tenant,
-		Path:     "/" + c.AltID + "/" + c.GroupOwner + "/" + c.ExtraID,
-		Scheme:   Scheme,
-		RawQuery: format.BuildQuery(resolver),
+		Scheme:     Scheme,
+		Host:       "",
+		ForceQuery: true,
+		RawQuery:   format.BuildQuery(resolver),
 	}
 }
 
-// setFromWebhookParts sets Config fields from webhook parts.
-func (c *Config) setFromWebhookParts(parts *[5]string) {
-	c.Group = parts[0]
-	c.Tenant = parts[1]
-	c.AltID = parts[2]
-	c.GroupOwner = parts[3]
-	c.ExtraID = parts[4]
-}
-
-// setQueryParams applies query parameters to the Config using the resolver.
-// It resets Color, Host, and Title, then updates them based on query values.
-// Returns an error if the resolver fails to set any parameter.
-func (c *Config) setQueryParams(resolver types.ConfigQueryResolver, query url.Values) error {
+func (c *Config) setURL(resolver types.ConfigQueryResolver, serviceURL *url.URL) error {
 	c.Color = ""
-	c.Host = ""
 	c.Title = ""
+	c.Host = ""
 
-	for key, vals := range query {
+	for key, vals := range serviceURL.Query() {
 		if len(vals) > 0 && vals[0] != "" {
-			switch key {
-			case "color":
-				c.Color = vals[0]
-			case "host":
-				c.Host = vals[0]
-			case "title":
-				c.Title = vals[0]
-			}
-
 			if err := resolver.Set(key, vals[0]); err != nil {
-				return fmt.Errorf(
-					"%w: key=%q, value=%q: %w",
-					ErrSetParameterFailed,
-					key,
-					vals[0],
-					err,
-				)
+				if errors.Is(err, format.ErrInvalidConfigKey) {
+					continue
+				}
+
+				return fmt.Errorf("setting config value for key %q: %w", key, err)
 			}
 		}
 	}
 
 	return nil
-}
-
-// setURL updates the Config from a URL using the provided resolver.
-// It parses the URL parts, sets query parameters, and ensures the host is specified.
-// Returns an error if the URL is invalid or the host is missing.
-func (c *Config) setURL(resolver types.ConfigQueryResolver, serviceURL *url.URL) error {
-	parts, err := parseURLParts(serviceURL)
-	if err != nil {
-		return err
-	}
-
-	c.setFromWebhookParts(&parts)
-
-	if err := c.setQueryParams(resolver, serviceURL.Query()); err != nil {
-		return err
-	}
-
-	// Allow dummy URL during documentation generation
-	if c.Host == "" && (serviceURL.User != nil && serviceURL.User.Username() == "dummy") {
-		c.Host = "dummy.webhook.office.com"
-	} else if c.Host == "" {
-		return ErrMissingHostParameter
-	}
-
-	return nil
-}
-
-// ConfigFromWebhookURL creates a new Config from a parsed Teams webhook URL.
-func ConfigFromWebhookURL(webhookURL *url.URL) (*Config, error) {
-	webhookURL.RawQuery = ""
-	config := &Config{
-		EnumlessConfig: standard.EnumlessConfig{},
-		Host:           webhookURL.Host,
-		Group:          "",
-		Tenant:         "",
-		AltID:          "",
-		GroupOwner:     "",
-		ExtraID:        "",
-		Title:          "",
-		Color:          "",
-	}
-
-	if err := config.SetFromWebhookURL(webhookURL.String()); err != nil {
-		return nil, err
-	}
-
-	return config, nil
-}
-
-// parseURLParts extracts and validates webhook components from a URL.
-func parseURLParts(serviceURL *url.URL) ([5]string, error) {
-	var parts [5]string
-	if serviceURL.String() == dummyURL {
-		return parts, nil
-	}
-
-	pathParts := strings.Split(serviceURL.Path, "/")
-	if pathParts[0] == "" {
-		pathParts = pathParts[1:]
-	}
-
-	if len(pathParts) < MinPathComponents {
-		return parts, ErrMissingExtraIDComponent
-	}
-
-	parts = [5]string{
-		serviceURL.User.Username(),
-		serviceURL.Hostname(),
-		pathParts[0],
-		pathParts[1],
-		pathParts[2],
-	}
-	if err := verifyWebhookParts(&parts); err != nil {
-		return parts, fmt.Errorf("invalid URL format: %w", err)
-	}
-
-	return parts, nil
 }

--- a/pkg/services/chat/teams/teams_config.go
+++ b/pkg/services/chat/teams/teams_config.go
@@ -14,9 +14,9 @@ import (
 type Config struct {
 	standard.EnumlessConfig
 
-	Host  string `key:"host"  optional:""`
-	Title string `key:"title" optional:""`
-	Color string `key:"color" optional:""`
+	Host  string `desc:"The full Power Automate workflow incoming webhook URL"                   key:"host"`
+	Title string `desc:"Title displayed as a bold header in the Adaptive Card"                   key:"title" optional:""`
+	Color string `desc:"Hex color code for the title text and card accent (e.g. FF0000 for red)" key:"color" optional:""`
 }
 
 // Scheme is the identifier for the Teams service protocol.

--- a/pkg/services/chat/teams/teams_errors.go
+++ b/pkg/services/chat/teams/teams_errors.go
@@ -4,47 +4,17 @@ import "errors"
 
 // Error variables for the Teams package.
 var (
-	// ErrInvalidWebhookFormat indicates the webhook URL doesn't contain the organization domain.
-	ErrInvalidWebhookFormat = errors.New(
-		"invalid webhook URL format - must contain organization domain",
-	)
-
-	// ErrMissingHostParameter indicates the required host parameter is missing.
-	ErrMissingHostParameter = errors.New(
-		"missing required host parameter (organization.webhook.office.com)",
-	)
-
-	// ErrMissingExtraIDComponent indicates the URL is missing the extraId component.
-	ErrMissingExtraIDComponent = errors.New("invalid URL format: missing extraId component")
-
-	// ErrMissingHost indicates the host is not specified in the configuration.
+	// ErrMissingHost indicates the host webhook URL is not specified in the configuration.
 	ErrMissingHost = errors.New("host is required but not specified in the configuration")
 
-	// ErrSetParameterFailed indicates failure to set a configuration parameter.
-	ErrSetParameterFailed = errors.New("failed to set configuration parameter")
+	// ErrSendFailed indicates a general failure in sending the notification.
+	ErrSendFailed = errors.New("an error occurred while sending notification to teams")
 
 	// ErrSendFailedStatus indicates an unexpected status code in the response.
 	ErrSendFailedStatus = errors.New(
 		"failed to send notification to teams, response status code unexpected",
 	)
 
-	// ErrSendFailed indicates a general failure in sending the notification.
-	ErrSendFailed = errors.New("an error occurred while sending notification to teams")
-
 	// ErrInvalidWebhookURL indicates the webhook URL format is invalid.
 	ErrInvalidWebhookURL = errors.New("invalid webhook URL format")
-
-	// ErrInvalidHostFormat indicates the host format is invalid.
-	ErrInvalidHostFormat = errors.New("invalid host format")
-
-	// ErrInvalidWebhookComponents indicates a mismatch in expected webhook URL components.
-	ErrInvalidWebhookComponents = errors.New(
-		"invalid webhook URL format: expected component count mismatch",
-	)
-
-	// ErrInvalidPartLength indicates a webhook component has an incorrect length.
-	ErrInvalidPartLength = errors.New("invalid webhook part length")
-
-	// ErrMissingExtraID indicates the extraID is missing.
-	ErrMissingExtraID = errors.New("extraID is required")
 )

--- a/pkg/services/chat/teams/teams_service.go
+++ b/pkg/services/chat/teams/teams_service.go
@@ -110,17 +110,26 @@ func (s *Service) doSend(config *Config, message string) error {
 	body := make([]adaptiveBlock, 0, len(lines)+1)
 
 	if config.Title != "" {
-		//nolint:exhaustruct // Weight, Size, Wrap are optional and default to zero values
-		body = append(body, adaptiveBlock{
+		//nolint:exhaustruct // Color, Wrap are optional and set conditionally
+		titleBlock := adaptiveBlock{
 			Type:   "TextBlock",
 			Text:   config.Title,
 			Weight: "Bolder",
 			Size:   "Medium",
-		})
+		}
+		if config.Color != "" {
+			titleBlock.Color = config.Color
+		}
+
+		body = append(body, titleBlock)
 	}
 
 	for _, line := range lines {
-		//nolint:exhaustruct // Weight, Size are optional and default to zero values
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		//nolint:exhaustruct // Color, Weight, Size are optional and default to zero values
 		body = append(body, adaptiveBlock{
 			Type: "TextBlock",
 			Text: line,
@@ -135,10 +144,11 @@ func (s *Service) doSend(config *Config, message string) error {
 				ContentType: "application/vnd.microsoft.card.adaptive",
 				ContentURL:  nil,
 				Content: adaptiveCardContent{
-					Schema:  "http://adaptivecards.io/schemas/adaptive-card.json",
-					Type:    "AdaptiveCard",
-					Version: adaptiveCardVersion,
-					Body:    body,
+					Schema:      "http://adaptivecards.io/schemas/adaptive-card.json",
+					Type:        "AdaptiveCard",
+					Version:     adaptiveCardVersion,
+					AccentColor: config.Color,
+					Body:        body,
 				},
 			},
 		},

--- a/pkg/services/chat/teams/teams_service.go
+++ b/pkg/services/chat/teams/teams_service.go
@@ -38,7 +38,7 @@ type Service struct {
 const defaultHTTPTimeout = 30 * time.Second
 
 // adaptiveCardVersion is the Adaptive Card schema version used in payloads.
-const adaptiveCardVersion = "1.5"
+const adaptiveCardVersion = "1.2"
 
 // Do performs the HTTP request.
 func (c *defaultHTTPClient) Do(req *http.Request) (*http.Response, error) {
@@ -96,6 +96,28 @@ func (s *Service) SetHTTPClient(client HTTPClient) {
 	s.httpClient = client
 }
 
+// colorToEnum maps user-provided color values to valid Adaptive Card TextBlock.color enum values.
+func colorToEnum(color string) string {
+	switch strings.ToLower(color) {
+	case "red", "attention", "danger":
+		return "attention"
+	case "orange", "yellow", "warning", "warn":
+		return "warning"
+	case "green", "good", "success":
+		return "good"
+	case "blue", "accent":
+		return "accent"
+	case "dark":
+		return "dark"
+	case "light":
+		return "light"
+	case "default", "":
+		return "default"
+	default:
+		return "default"
+	}
+}
+
 // doSend sends the notification to Teams as an Adaptive Card payload.
 func (s *Service) doSend(config *Config, message string) error {
 	if config.Host == "" {
@@ -116,9 +138,7 @@ func (s *Service) doSend(config *Config, message string) error {
 			Text:   config.Title,
 			Weight: "Bolder",
 			Size:   "Medium",
-		}
-		if config.Color != "" {
-			titleBlock.Color = config.Color
+			Color:  colorToEnum(config.Color),
 		}
 
 		body = append(body, titleBlock)
@@ -144,11 +164,10 @@ func (s *Service) doSend(config *Config, message string) error {
 				ContentType: "application/vnd.microsoft.card.adaptive",
 				ContentURL:  nil,
 				Content: adaptiveCardContent{
-					Schema:      "http://adaptivecards.io/schemas/adaptive-card.json",
-					Type:        "AdaptiveCard",
-					Version:     adaptiveCardVersion,
-					AccentColor: config.Color,
-					Body:        body,
+					Schema:  "http://adaptivecards.io/schemas/adaptive-card.json",
+					Type:    "AdaptiveCard",
+					Version: adaptiveCardVersion,
+					Body:    body,
 				},
 			},
 		},

--- a/pkg/services/chat/teams/teams_service.go
+++ b/pkg/services/chat/teams/teams_service.go
@@ -15,26 +15,43 @@ import (
 	"github.com/nicholas-fedor/shoutrrr/pkg/types"
 )
 
-// Service sends notifications to Microsoft Teams.
+// HTTPClient defines the interface for HTTP operations.
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// defaultHTTPClient implements HTTPClient using http.Client with a timeout.
+type defaultHTTPClient struct {
+	client *http.Client
+}
+
+// Service sends notifications to Microsoft Teams via Power Automate workflow webhooks.
 type Service struct {
 	standard.Standard
 
 	Config     *Config
 	pkr        format.PropKeyResolver
-	httpClient *http.Client
+	httpClient HTTPClient
 }
 
 // defaultHTTPTimeout is the default timeout for HTTP requests.
 const defaultHTTPTimeout = 30 * time.Second
 
-// MaxSummaryLength defines the maximum length for a notification summary.
-const MaxSummaryLength = 20
+// adaptiveCardVersion is the Adaptive Card schema version used in payloads.
+const adaptiveCardVersion = "1.5"
 
-// TruncatedSummaryLen defines the length for a truncated summary.
-const TruncatedSummaryLen = 21
+// Do performs the HTTP request.
+func (c *defaultHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("performing HTTP request: %w", err)
+	}
+
+	return resp, nil
+}
 
 // GetHTTPClient returns the service's HTTP client for testing purposes.
-func (s *Service) GetHTTPClient() *http.Client {
+func (s *Service) GetHTTPClient() HTTPClient {
 	return s.httpClient
 }
 
@@ -43,130 +60,101 @@ func (s *Service) GetID() string {
 	return Scheme
 }
 
-// GetServiceURLFromCustom converts a custom URL to a service URL.
-func (s *Service) GetServiceURLFromCustom(customURL *url.URL) (*url.URL, error) {
-	webhookURLStr := strings.TrimPrefix(customURL.String(), "teams+")
-
-	tempURL, err := url.Parse(webhookURLStr)
-	if err != nil {
-		return nil, fmt.Errorf("parsing custom URL %q: %w", webhookURLStr, err)
-	}
-
-	webhookURL := &url.URL{
-		Scheme: tempURL.Scheme,
-		Host:   tempURL.Host,
-		Path:   tempURL.Path,
-	}
-
-	config, err := ConfigFromWebhookURL(webhookURL)
-	if err != nil {
-		return nil, err
-	}
-
-	config.Color = ""
-	config.Title = ""
-
-	query := customURL.Query()
-	for key, vals := range query {
-		if vals[0] != "" {
-			switch key {
-			case "color":
-				config.Color = vals[0]
-			case "host":
-				config.Host = vals[0]
-			case "title":
-				config.Title = vals[0]
-			}
-		}
-	}
-
-	return config.GetURL(), nil
-}
-
 // Initialize configures the service with a URL and logger.
 func (s *Service) Initialize(serviceURL *url.URL, logger types.StdLogger) error {
 	s.SetLogger(logger)
+
 	s.Config = &Config{}
 	s.pkr = format.NewPropKeyResolver(s.Config)
+	s.httpClient = &defaultHTTPClient{
+		client: &http.Client{Timeout: defaultHTTPTimeout},
+	}
 
-	s.httpClient = &http.Client{Timeout: defaultHTTPTimeout}
+	if err := s.pkr.SetDefaultProps(s.Config); err != nil {
+		return fmt.Errorf("setting default properties: %w", err)
+	}
 
 	return s.Config.SetURL(serviceURL)
 }
 
 // Send delivers a notification message to Microsoft Teams.
 func (s *Service) Send(message string, params *types.Params) error {
-	config := s.Config
-	if err := s.pkr.UpdateConfigFromParams(config, params); err != nil {
-		s.Logf("Failed to update params: %v", err)
+	if s.Config == nil {
+		return ErrMissingHost
 	}
 
-	return s.doSend(config, message)
+	config := *s.Config
+	if err := s.pkr.UpdateConfigFromParams(&config, params); err != nil {
+		return fmt.Errorf("updating config from params: %w", err)
+	}
+
+	return s.doSend(&config, message)
 }
 
-// doSend sends the notification to Teams using the configured webhook URL.
+// SetHTTPClient sets the HTTP client for testing purposes.
+func (s *Service) SetHTTPClient(client HTTPClient) {
+	s.httpClient = client
+}
+
+// doSend sends the notification to Teams as an Adaptive Card payload.
 func (s *Service) doSend(config *Config, message string) error {
-	lines := strings.Split(message, "\n")
-	sections := make([]section, 0, len(lines))
-
-	for _, line := range lines {
-		sections = append(sections, section{
-			Text:             line,
-			ActivityTitle:    "",
-			ActivitySubtitle: "",
-			ActivityImage:    "",
-			Facts:            nil,
-			Images:           nil,
-			Actions:          nil,
-			HeroImage:        nil,
-		})
-	}
-
-	summary := config.Title
-	if summary == "" && len(sections) > 0 {
-		summary = sections[0].Text
-		if len(summary) > MaxSummaryLength {
-			summary = summary[:TruncatedSummaryLen]
-		}
-	}
-
-	payload, err := json.Marshal(payload{
-		CardType:   "MessageCard",
-		Context:    "http://schema.org/extensions",
-		Markdown:   true,
-		Title:      config.Title,
-		ThemeColor: config.Color,
-		Summary:    summary,
-		Sections:   sections,
-	})
-	if err != nil {
-		return fmt.Errorf("marshaling payload to JSON: %w", err)
-	}
-
 	if config.Host == "" {
 		return ErrMissingHost
 	}
 
-	postURL := BuildWebhookURL(
-		config.Host,
-		config.Group,
-		config.Tenant,
-		config.AltID,
-		config.GroupOwner,
-		config.ExtraID,
-	)
-
-	// Validate URL before sending
-	if err := ValidateWebhookURL(postURL); err != nil {
+	if err := ValidateWebhookURL(config.Host); err != nil {
 		return err
 	}
 
-	res, err := s.postJSON(postURL, payload)
+	lines := strings.Split(message, "\n")
+	body := make([]adaptiveBlock, 0, len(lines)+1)
+
+	if config.Title != "" {
+		//nolint:exhaustruct // Weight, Size, Wrap are optional and default to zero values
+		body = append(body, adaptiveBlock{
+			Type:   "TextBlock",
+			Text:   config.Title,
+			Weight: "Bolder",
+			Size:   "Medium",
+		})
+	}
+
+	for _, line := range lines {
+		//nolint:exhaustruct // Weight, Size are optional and default to zero values
+		body = append(body, adaptiveBlock{
+			Type: "TextBlock",
+			Text: line,
+			Wrap: true,
+		})
+	}
+
+	payload := adaptivePayload{
+		Type: "message",
+		Attachments: []adaptiveAttachment{
+			{
+				ContentType: "application/vnd.microsoft.card.adaptive",
+				ContentURL:  nil,
+				Content: adaptiveCardContent{
+					Schema:  "http://adaptivecards.io/schemas/adaptive-card.json",
+					Type:    "AdaptiveCard",
+					Version: adaptiveCardVersion,
+					Body:    body,
+				},
+			},
+		},
+	}
+
+	jsonBytes, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshaling payload to JSON: %w", err)
+	}
+
+	res, err := s.postJSON(config.Host, jsonBytes)
 	if err != nil {
 		return fmt.Errorf("%w: %s", ErrSendFailed, err.Error())
 	}
 
-	defer func() { _ = res.Body.Close() }() // Move defer after error check
+	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusOK {
 		return fmt.Errorf("%w: %s", ErrSendFailedStatus, res.Status)
@@ -175,7 +163,7 @@ func (s *Service) doSend(config *Config, message string) error {
 	return nil
 }
 
-// postJSON performs an HTTP POST with a pre-validated URL using the service's HTTP client.
+// postJSON performs an HTTP POST with a JSON payload.
 func (s *Service) postJSON(serviceURL string, payload []byte) (*http.Response, error) {
 	ctx, cancel := context.WithTimeout(
 		context.Background(),

--- a/pkg/services/chat/teams/teams_test.go
+++ b/pkg/services/chat/teams/teams_test.go
@@ -3,6 +3,7 @@ package teams
 import (
 	"errors"
 	"log"
+	"net/http"
 	"net/url"
 	"testing"
 
@@ -12,96 +13,14 @@ import (
 )
 
 const (
-	extraIDValue     = "V2ESyij_gAljSoUQHvZoZYzlpAoAXExyOl26dlf1xHEx05"
-	scopedWebhookURL = "https://test.webhook.office.com/webhookb2/11111111-4444-4444-8444-cccccccccccc@22222222-4444-4444-8444-cccccccccccc/IncomingWebhook/33333301222222222233333333333344/44444444-4444-4444-8444-cccccccccccc/" + extraIDValue
-	scopedDomainHost = "test.webhook.office.com"
-	testURLBase      = "teams://11111111-4444-4444-8444-cccccccccccc@22222222-4444-4444-8444-cccccccccccc/33333301222222222233333333333344/44444444-4444-4444-8444-cccccccccccc/" + extraIDValue
+	workflowURL = "https://prod-00.westus.logic.azure.com:443/workflows/abc123/triggers/manual/paths/invoke?api-version=2016-06-00&sp=/triggers/manual/run&sv=1.0&sig=XXXXXXXX"
 )
+
+var serviceURLBase = "teams://?host=" + url.QueryEscape(workflowURL)
 
 var logger = log.New(ginkgo.GinkgoWriter, "Test", log.LstdFlags)
 
 var _ = ginkgo.Describe("the teams service", func() {
-	ginkgo.When("creating the webhook URL", func() {
-		ginkgo.It("should match the expected output for custom URLs", func() {
-			config := Config{}
-			config.setFromWebhookParts(&[5]string{
-				"11111111-4444-4444-8444-cccccccccccc",
-				"22222222-4444-4444-8444-cccccccccccc",
-				"33333301222222222233333333333344",
-				"44444444-4444-4444-8444-cccccccccccc",
-				extraIDValue,
-			})
-			apiURL := BuildWebhookURL(
-				scopedDomainHost,
-				config.Group,
-				config.Tenant,
-				config.AltID,
-				config.GroupOwner,
-				config.ExtraID,
-			)
-			gomega.Expect(apiURL).To(gomega.Equal(scopedWebhookURL))
-
-			parts, err := ParseAndVerifyWebhookURL(apiURL)
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			gomega.Expect(parts).To(gomega.Equal(config.WebhookParts()))
-		})
-	})
-
-	ginkgo.Describe("creating a config", func() {
-		ginkgo.When("parsing the configuration URL", func() {
-			ginkgo.It("should be identical after de-/serialization", func() {
-				testURL := testURLBase + "?color=aabbcc&host=test.webhook.office.com&title=Test+title"
-				url, err := url.Parse(testURL)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "parsing")
-
-				config := &Config{}
-				err = config.SetURL(url)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "verifying")
-
-				outputURL := config.GetURL()
-				gomega.Expect(outputURL.String()).To(gomega.Equal(testURL))
-			})
-		})
-	})
-
-	ginkgo.Describe("converting custom URL to service URL", func() {
-		ginkgo.When("an invalid custom URL is provided", func() {
-			ginkgo.It("should return an error", func() {
-				service := Service{}
-				testURL := "teams+https://google.com/search?q=what+is+love"
-				customURL, err := url.Parse(testURL)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "parsing")
-
-				_, err = service.GetServiceURLFromCustom(customURL)
-				gomega.Expect(err).To(gomega.HaveOccurred(), "converting")
-			})
-		})
-		ginkgo.When("a valid custom URL is provided", func() {
-			ginkgo.It("should set the host field from the custom URL", func() {
-				service := Service{}
-				testURL := `teams+` + scopedWebhookURL
-				customURL, err := url.Parse(testURL)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "parsing")
-
-				serviceURL, err := service.GetServiceURLFromCustom(customURL)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "converting")
-				gomega.Expect(serviceURL.String()).To(gomega.Equal(testURLBase + "?host=" + scopedDomainHost))
-			})
-			ginkgo.It("should preserve the query params in the generated service URL", func() {
-				service := Service{}
-				testURL := "teams+" + scopedWebhookURL + "?color=f008c1&title=TheTitle"
-				customURL, err := url.Parse(testURL)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "parsing")
-
-				serviceURL, err := service.GetServiceURLFromCustom(customURL)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "converting")
-
-				expectedURL := testURLBase + "?color=f008c1&host=test.webhook.office.com&title=TheTitle"
-				gomega.Expect(serviceURL.String()).To(gomega.Equal(expectedURL))
-			})
-		})
-	})
-
 	ginkgo.Describe("sending the payload", func() {
 		var (
 			err     error
@@ -115,27 +34,41 @@ var _ = ginkgo.Describe("the teams service", func() {
 			httpmock.DeactivateAndReset()
 		})
 		ginkgo.It("should not report an error if the server accepts the payload", func() {
-			serviceURL, _ := url.Parse(testURLBase + "?host=" + scopedDomainHost)
+			serviceURL, _ := url.Parse(serviceURLBase)
 			err = service.Initialize(serviceURL, logger)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			httpmock.RegisterResponder(
 				"POST",
-				scopedWebhookURL,
-				httpmock.NewStringResponder(200, ""),
+				workflowURL,
+				httpmock.NewStringResponder(http.StatusOK, ""),
 			)
 
 			err = service.Send("Message", nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
-		ginkgo.It("should not panic if an error occurs when sending the payload", func() {
-			serviceURL, _ := url.Parse(testURLBase + "?host=test.webhook.office.com")
+		ginkgo.It("should report an error if the server returns non-200", func() {
+			serviceURL, _ := url.Parse(serviceURLBase)
 			err = service.Initialize(serviceURL, logger)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			httpmock.RegisterResponder(
 				"POST",
-				scopedWebhookURL,
+				workflowURL,
+				httpmock.NewStringResponder(http.StatusInternalServerError, ""),
+			)
+
+			err = service.Send("Message", nil)
+			gomega.Expect(err).To(gomega.HaveOccurred())
+		})
+		ginkgo.It("should not panic if an HTTP error occurs when sending the payload", func() {
+			serviceURL, _ := url.Parse(serviceURLBase)
+			err = service.Initialize(serviceURL, logger)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			httpmock.RegisterResponder(
+				"POST",
+				workflowURL,
 				httpmock.NewErrorResponder(errors.New("dummy error")),
 			)
 
@@ -149,116 +82,122 @@ var _ = ginkgo.Describe("the teams service", func() {
 		gomega.Expect(service.GetID()).To(gomega.Equal("teams"))
 	})
 
-	// Config tests
 	ginkgo.Describe("the teams config", func() {
 		ginkgo.Describe("setURL", func() {
 			ginkgo.It("should set all fields correctly from URL", func() {
 				config := &Config{}
-				urlStr := testURLBase + "?title=Test&color=red&host=test.webhook.office.com"
+				urlStr := serviceURLBase + "&title=Test&color=red"
 				parsedURL, err := url.Parse(urlStr)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				err = config.SetURL(parsedURL)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				gomega.Expect(config.Group).To(gomega.Equal("11111111-4444-4444-8444-cccccccccccc"))
-				gomega.Expect(config.Tenant).
-					To(gomega.Equal("22222222-4444-4444-8444-cccccccccccc"))
-				gomega.Expect(config.AltID).To(gomega.Equal("33333301222222222233333333333344"))
-				gomega.Expect(config.GroupOwner).
-					To(gomega.Equal("44444444-4444-4444-8444-cccccccccccc"))
-				gomega.Expect(config.ExtraID).To(gomega.Equal(extraIDValue))
+				gomega.Expect(config.Host).To(gomega.Equal(workflowURL))
 				gomega.Expect(config.Title).To(gomega.Equal("Test"))
 				gomega.Expect(config.Color).To(gomega.Equal("red"))
-				gomega.Expect(config.Host).To(gomega.Equal("test.webhook.office.com"))
 			})
 
-			ginkgo.It("should reject URLs missing the extraID", func() {
+			ginkgo.It("should silently skip unknown query params from workflow URL", func() {
 				config := &Config{}
-				urlStr := "teams://11111111-4444-4444-8444-cccccccccccc@22222222-4444-4444-8444-cccccccccccc/33333301222222222233333333333344/44444444-4444-4444-8444-cccccccccccc?host=test.webhook.office.com"
+				// Simulates the query params appended by Power Automate workflow URLs
+				urlStr := serviceURLBase + "&api-version=2016-06-00&sp=/triggers/manual/run&sv=1.0&sig=XXXXXXXX"
 				parsedURL, err := url.Parse(urlStr)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				err = config.SetURL(parsedURL)
-				gomega.Expect(err).To(gomega.HaveOccurred())
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(config.Host).To(gomega.Equal(workflowURL))
 			})
 
-			ginkgo.It("should require the host parameter", func() {
+			ginkgo.It("should propagate errors for known keys with invalid values", func() {
 				config := &Config{}
-				urlStr := testURLBase
+				// All config fields are strings, so any value is valid for them.
+				// This test confirms the error path is exercised — if a future
+				// field type rejects input, the error will surface.
+				urlStr := serviceURLBase + "&title=Test"
 				parsedURL, err := url.Parse(urlStr)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				err = config.SetURL(parsedURL)
-				gomega.Expect(err).To(gomega.HaveOccurred())
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			})
 		})
 
 		ginkgo.Describe("getURL", func() {
-			ginkgo.It("should generate correct URL with all parameters", func() {
+			ginkgo.It("should generate URL containing host, title, and color params", func() {
 				config := &Config{
-					Group:      "11111111-4444-4444-8444-cccccccccccc",
-					Tenant:     "22222222-4444-4444-8444-cccccccccccc",
-					AltID:      "33333301222222222233333333333344",
-					GroupOwner: "44444444-4444-4444-8444-cccccccccccc",
-					ExtraID:    extraIDValue,
-					Title:      "Test",
-					Color:      "red",
-					Host:       "test.webhook.office.com",
+					Host:  workflowURL,
+					Title: "Test",
+					Color: "red",
 				}
 
 				urlObj := config.GetURL()
 				urlStr := urlObj.String()
-				expectedURL := testURLBase + "?color=red&host=test.webhook.office.com&title=Test"
-				gomega.Expect(urlStr).To(gomega.Equal(expectedURL))
+				gomega.Expect(urlStr).To(gomega.ContainSubstring("host="))
+				gomega.Expect(urlStr).To(gomega.ContainSubstring("color=red"))
+				gomega.Expect(urlStr).To(gomega.ContainSubstring("title=Test"))
 			})
 		})
+	})
 
-		ginkgo.Describe("verifyWebhookParts", func() {
-			ginkgo.It("should validate correct webhook parts", func() {
-				parts := [5]string{
-					"11111111-4444-4444-8444-cccccccccccc",
-					"22222222-4444-4444-8444-cccccccccccc",
-					"33333301222222222233333333333344",
-					"44444444-4444-4444-8444-cccccccccccc",
-					extraIDValue,
-				}
-				err := verifyWebhookParts(&parts)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			})
+	ginkgo.Describe("Initialize", func() {
+		ginkgo.It("should initialize with a valid workflow URL", func() {
+			service := &Service{}
+			serviceURL, _ := url.Parse(serviceURLBase)
+			err := service.Initialize(serviceURL, logger)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(service.Config).NotTo(gomega.BeNil())
+			gomega.Expect(service.Config.Host).To(gomega.Equal(workflowURL))
+		})
+	})
 
-			ginkgo.It("should reject invalid group ID", func() {
-				parts := [5]string{
-					"invalid-id",
-					"22222222-4444-4444-8444-cccccccccccc",
-					"33333333012222222222333333333344",
-					"44444444-4444-4444-8444-cccccccccccc",
-					extraIDValue,
-				}
-				err := verifyWebhookParts(&parts)
-				gomega.Expect(err).To(gomega.HaveOccurred())
-			})
+	ginkgo.Describe("ValidateWebhookURL", func() {
+		ginkgo.It("should accept valid Power Automate workflow URLs", func() {
+			validURLs := []string{
+				"https://prod-00.westus.logic.azure.com:443/workflows/abc123/triggers/manual/paths/invoke",
+				"https://prod-00.westus.logic.azure.com/workflows/abc123/triggers/manual/paths/invoke",
+				"https://mytenant.logic.azure.com/workflows/abc123/triggers/manual/paths/invoke?api-version=2016-06-00",
+				"https://prod-00.westus.logic.azure.us/workflows/abc123/triggers/manual/paths/invoke",
+				"https://prod-00.westus.logic.azure.cn/workflows/abc123/triggers/manual/paths/invoke",
+				"https://prod-00.westus.logic.azure.de/workflows/abc123/triggers/manual/paths/invoke",
+			}
+			for _, u := range validURLs {
+				err := ValidateWebhookURL(u)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "URL: %s", u)
+			}
 		})
 
-		ginkgo.Describe("parseAndVerifyWebhookURL", func() {
-			ginkgo.It("should correctly parse valid webhook URL", func() {
-				webhookURL := scopedWebhookURL
-				parts, err := ParseAndVerifyWebhookURL(webhookURL)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Expect(parts).To(gomega.Equal([5]string{
-					"11111111-4444-4444-8444-cccccccccccc",
-					"22222222-4444-4444-8444-cccccccccccc",
-					"33333301222222222233333333333344",
-					"44444444-4444-4444-8444-cccccccccccc",
-					extraIDValue,
-				}))
-			})
+		ginkgo.It("should reject invalid URLs", func() {
+			invalidURLs := []string{
+				"https://example.com/webhook",
+				"",
+			}
+			for _, u := range invalidURLs {
+				err := ValidateWebhookURL(u)
+				gomega.Expect(err).To(gomega.HaveOccurred(), "URL: %s", u)
+			}
+		})
+	})
 
-			ginkgo.It("should reject invalid webhook URL", func() {
-				webhookURL := "https://teams.microsoft.com/invalid/webhook/url"
-				_, err := ParseAndVerifyWebhookURL(webhookURL)
-				gomega.Expect(err).To(gomega.HaveOccurred())
-			})
+	ginkgo.Describe("doSend", func() {
+		ginkgo.It("should return ErrMissingHost when host is empty", func() {
+			service := &Service{}
+			service.Config = &Config{}
+			service.SetLogger(logger)
+
+			err := service.doSend(&Config{}, "test message")
+			gomega.Expect(err).To(gomega.Equal(ErrMissingHost))
+		})
+
+		ginkgo.It("should return ErrInvalidWebhookURL for invalid host before any HTTP call", func() {
+			service := &Service{}
+			service.Config = &Config{}
+			service.SetLogger(logger)
+
+			// No httpmock activated — this must fail at validation, not at the network layer.
+			err := service.doSend(&Config{Host: "https://example.com"}, "test message")
+			gomega.Expect(err).To(gomega.MatchError(ErrInvalidWebhookURL))
 		})
 	})
 })

--- a/pkg/services/chat/teams/teams_test.go
+++ b/pkg/services/chat/teams/teams_test.go
@@ -110,17 +110,15 @@ var _ = ginkgo.Describe("the teams service", func() {
 				gomega.Expect(config.Host).To(gomega.Equal(workflowURL))
 			})
 
-			ginkgo.It("should propagate errors for known keys with invalid values", func() {
+			ginkgo.It("should accept valid string values for known keys", func() {
 				config := &Config{}
-				// All config fields are strings, so any value is valid for them.
-				// This test confirms the error path is exercised — if a future
-				// field type rejects input, the error will surface.
 				urlStr := serviceURLBase + "&title=Test"
 				parsedURL, err := url.Parse(urlStr)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				err = config.SetURL(parsedURL)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(config.Title).To(gomega.Equal("Test"))
 			})
 		})
 

--- a/pkg/services/chat/teams/teams_types.go
+++ b/pkg/services/chat/teams/teams_types.go
@@ -1,62 +1,31 @@
 package teams
 
-// payload is the main structure for a Teams message card.
-type payload struct {
-	CardType   string    `json:"@type"`
-	Context    string    `json:"@context"`
-	ThemeColor string    `json:"themeColor,omitempty"`
-	Summary    string    `json:"summary"`
-	Title      string    `json:"title,omitempty"`
-	Markdown   bool      `json:"markdown"`
-	Sections   []section `json:"sections"`
+// adaptivePayload is the wrapper for a Teams Power Automate webhook Adaptive Card message.
+type adaptivePayload struct {
+	Type        string               `json:"type"`
+	Attachments []adaptiveAttachment `json:"attachments"`
 }
 
-// section represents a section of a Teams message card.
-type section struct {
-	ActivityTitle    string    `json:"activityTitle,omitempty"`
-	ActivitySubtitle string    `json:"activitySubtitle,omitempty"`
-	ActivityImage    string    `json:"activityImage,omitempty"`
-	Facts            []fact    `json:"facts,omitempty"`
-	Text             string    `json:"text,omitempty"`
-	Images           []image   `json:"images,omitempty"`
-	Actions          []action  `json:"potentialAction,omitempty"`
-	HeroImage        *heroCard `json:"heroImage,omitempty"`
+// adaptiveAttachment represents a single Adaptive Card attachment.
+type adaptiveAttachment struct {
+	ContentType string              `json:"contentType"`
+	ContentURL  *string             `json:"contentUrl"`
+	Content     adaptiveCardContent `json:"content"`
 }
 
-// fact represents a key-value pair in a Teams message card.
-type fact struct {
-	Name  string `json:"name"`
-	Value string `json:"value"`
+// adaptiveCardContent is the Adaptive Card JSON body.
+type adaptiveCardContent struct {
+	Schema  string          `json:"$schema"`
+	Type    string          `json:"type"`
+	Version string          `json:"version"`
+	Body    []adaptiveBlock `json:"body"`
 }
 
-// image represents an image in a Teams message card.
-type image struct {
-	Image string `json:"image"`
-	Title string `json:"title,omitempty"`
-}
-
-// action represents an action button in a Teams message card.
-type action struct {
-	Type    string      `json:"@type"`
-	Name    string      `json:"name"`
-	Targets []target    `json:"targets,omitempty"`
-	Actions []subAction `json:"actions,omitempty"`
-}
-
-// target represents a target for an action in a Teams message card.
-type target struct {
-	OS  string `json:"os"`
-	URI string `json:"uri"`
-}
-
-// subAction represents a sub-action in a Teams message card.
-type subAction struct {
-	Type string `json:"@type"`
-	Name string `json:"name"`
-	URI  string `json:"uri"`
-}
-
-// heroCard represents a hero image in a Teams message card.
-type heroCard struct {
-	Image string `json:"image"`
+// adaptiveBlock is a single UI block within an Adaptive Card body.
+type adaptiveBlock struct {
+	Type   string `json:"type"`
+	Text   string `json:"text,omitempty"`
+	Weight string `json:"weight,omitempty"`
+	Size   string `json:"size,omitempty"`
+	Wrap   bool   `json:"wrap,omitempty"`
 }

--- a/pkg/services/chat/teams/teams_types.go
+++ b/pkg/services/chat/teams/teams_types.go
@@ -15,16 +15,18 @@ type adaptiveAttachment struct {
 
 // adaptiveCardContent is the Adaptive Card JSON body.
 type adaptiveCardContent struct {
-	Schema  string          `json:"$schema"`
-	Type    string          `json:"type"`
-	Version string          `json:"version"`
-	Body    []adaptiveBlock `json:"body"`
+	Schema      string          `json:"$schema"`
+	Type        string          `json:"type"`
+	Version     string          `json:"version"`
+	AccentColor string          `json:"accentColor,omitempty"`
+	Body        []adaptiveBlock `json:"body"`
 }
 
 // adaptiveBlock is a single UI block within an Adaptive Card body.
 type adaptiveBlock struct {
 	Type   string `json:"type"`
 	Text   string `json:"text,omitempty"`
+	Color  string `json:"color,omitempty"`
 	Weight string `json:"weight,omitempty"`
 	Size   string `json:"size,omitempty"`
 	Wrap   bool   `json:"wrap,omitempty"`

--- a/pkg/services/chat/teams/teams_types.go
+++ b/pkg/services/chat/teams/teams_types.go
@@ -15,11 +15,10 @@ type adaptiveAttachment struct {
 
 // adaptiveCardContent is the Adaptive Card JSON body.
 type adaptiveCardContent struct {
-	Schema      string          `json:"$schema"`
-	Type        string          `json:"type"`
-	Version     string          `json:"version"`
-	AccentColor string          `json:"accentColor,omitempty"`
-	Body        []adaptiveBlock `json:"body"`
+	Schema  string          `json:"$schema"`
+	Type    string          `json:"type"`
+	Version string          `json:"version"`
+	Body    []adaptiveBlock `json:"body"`
 }
 
 // adaptiveBlock is a single UI block within an Adaptive Card body.

--- a/pkg/services/chat/teams/teams_validation.go
+++ b/pkg/services/chat/teams/teams_validation.go
@@ -5,103 +5,15 @@ import (
 	"regexp"
 )
 
-// Validation constants.
-const (
-	UUID4Length        = 36 // Length of a UUID4 identifier
-	HashLength         = 32 // Length of a hash identifier
-	WebhookDomain      = `\.webhook\.office\.com`
-	ExpectedComponents = 7 // Expected number of components in webhook URL (1 match + 6 captures)
-	Path               = "webhookb2"
-	ProviderName       = "IncomingWebhook"
-
-	AltIDIndex      = 2 // Index of AltID in parts array
-	GroupOwnerIndex = 3 // Index of GroupOwner in parts array
+var workflowURLValidator = regexp.MustCompile(
+	`^https://[a-zA-Z0-9][a-zA-Z0-9.-]*\.logic\.azure(?:\.[a-z]{2,})?(:\d+)?/workflows/`,
 )
 
-var (
-	// HostValidator ensures the host matches the Teams webhook domain pattern.
-	HostValidator = regexp.MustCompile(`^[a-zA-Z0-9-]+\.webhook\.office\.com$`)
-	// WebhookURLValidator ensures the full webhook URL matches the Teams pattern.
-	WebhookURLValidator = regexp.MustCompile(
-		`^https://[a-zA-Z0-9-]+\.webhook\.office\.com/webhookb2/[0-9a-f-]{36}@[0-9a-f-]{36}/IncomingWebhook/[0-9a-f]{32}/[0-9a-f-]{36}/[^/]+$`,
-	)
-)
-
-// ValidateWebhookURL ensures the webhook URL is valid before use.
+// ValidateWebhookURL ensures the webhook URL matches the Power Automate workflow pattern.
 func ValidateWebhookURL(url string) error {
-	if !WebhookURLValidator.MatchString(url) {
+	if !workflowURLValidator.MatchString(url) {
 		return fmt.Errorf("%w: %q", ErrInvalidWebhookURL, url)
 	}
 
 	return nil
-}
-
-// ParseAndVerifyWebhookURL extracts and validates webhook components from a URL.
-func ParseAndVerifyWebhookURL(webhookURL string) ([5]string, error) {
-	pattern := regexp.MustCompile(
-		`https://([a-zA-Z0-9-\.]+)` + WebhookDomain + `/` + Path + `/([0-9a-f\-]{36})@([0-9a-f\-]{36})/` + ProviderName + `/([0-9a-f]{32})/([0-9a-f\-]{36})/([^/]+)`,
-	)
-
-	groups := pattern.FindStringSubmatch(webhookURL)
-	if len(groups) != ExpectedComponents {
-		return [5]string{}, fmt.Errorf(
-			"%w: expected %d components, got %d",
-			ErrInvalidWebhookComponents,
-			ExpectedComponents,
-			len(groups),
-		)
-	}
-
-	parts := [5]string{groups[2], groups[3], groups[4], groups[5], groups[6]}
-	if err := verifyWebhookParts(&parts); err != nil {
-		return [5]string{}, err
-	}
-
-	return parts, nil
-}
-
-// verifyWebhookParts ensures webhook components meet format requirements.
-func verifyWebhookParts(parts *[5]string) error {
-	type partSpec struct {
-		name     string
-		length   int
-		index    int
-		optional bool
-	}
-
-	specs := []partSpec{
-		{name: "group ID", length: UUID4Length, index: 0, optional: true},
-		{name: "tenant ID", length: UUID4Length, index: 1, optional: true},
-		{name: "altID", length: HashLength, index: AltIDIndex, optional: true},
-		{name: "groupOwner", length: UUID4Length, index: GroupOwnerIndex, optional: true},
-	}
-
-	for _, spec := range specs {
-		if len(parts[spec.index]) != spec.length && parts[spec.index] != "" {
-			return fmt.Errorf(
-				"%w: %s must be %d characters, got %d",
-				ErrInvalidPartLength,
-				spec.name,
-				spec.length,
-				len(parts[spec.index]),
-			)
-		}
-	}
-
-	if parts[4] == "" {
-		return ErrMissingExtraID
-	}
-
-	return nil
-}
-
-// BuildWebhookURL constructs a Teams webhook URL from components.
-func BuildWebhookURL(host, group, tenant, altID, groupOwner, extraID string) string {
-	// Host validation moved here for clarity
-	if !HostValidator.MatchString(host) {
-		return "" // Will trigger ErrInvalidHostFormat in caller
-	}
-
-	return fmt.Sprintf("https://%s/%s/%s@%s/%s/%s/%s/%s",
-		host, Path, group, tenant, ProviderName, altID, groupOwner, extraID)
 }

--- a/pkg/services/chat/teams/teams_validation.go
+++ b/pkg/services/chat/teams/teams_validation.go
@@ -12,7 +12,7 @@ var workflowURLValidator = regexp.MustCompile(
 // ValidateWebhookURL ensures the webhook URL matches the Power Automate workflow pattern.
 func ValidateWebhookURL(url string) error {
 	if !workflowURLValidator.MatchString(url) {
-		return fmt.Errorf("%w: %q", ErrInvalidWebhookURL, url)
+		return fmt.Errorf("%w", ErrInvalidWebhookURL)
 	}
 
 	return nil

--- a/pkg/services/services_test.go
+++ b/pkg/services/services_test.go
@@ -29,7 +29,7 @@ var serviceURLs = map[string]string{
 	"rocketchat": "rocketchat://example.com/token/channel",
 	"slack":      "slack://AAAAAAAAA/BBBBBBBBB/123456789123456789123456",
 	"smtp":       "smtp://host.tld:25/?fromAddress=from@host.tld&toAddresses=to@host.tld",
-	"teams":      "teams://11111111-4444-4444-8444-cccccccccccc@22222222-4444-4444-8444-cccccccccccc/33333333012222222222333333333344/44444444-4444-4444-8444-cccccccccccc/V2ESyij_gAljSoUQHvZoZYzlpAoAXExyOl26dlf1xHEx05?host=test.webhook.office.com",
+	"teams":      "teams://?host=https%3A%2F%2Fprod-00.westus.logic.azure.com%3A443%2Fworkflows%2F00000000-0000-0000-0000-000000000000%2Ftriggers%2Fmanual%2Fpaths%2Finvoke%3Fapi-version%3D2016-06-00%26sp%3D%2Ftriggers%2Fmanual%2Frun%26sv%3D1.0%26sig%3DXXXXXXXX",
 	"telegram":   "telegram://000000000:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA@telegram?channels=channel",
 	"twilio":     "twilio://ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:authToken@+15551234567/+15559876543",
 	"xmpp":       "xmpp://",

--- a/testing/integration/teams/config_test.go
+++ b/testing/integration/teams/config_test.go
@@ -1,0 +1,148 @@
+package teams_test
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+	"testing/synctest"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nicholas-fedor/shoutrrr/pkg/types"
+)
+
+var integrationBase = "teams://?host=" + url.QueryEscape(workflowURL)
+
+func TestServiceInitialization(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		service := createTestService(
+			t,
+			integrationBase,
+			mockClient,
+		)
+
+		require.NotNil(t, service)
+		require.Equal(t, "teams", service.GetID())
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithTitle(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		service := createTestService(
+			t,
+			integrationBase,
+			mockClient,
+		)
+
+		mockClient.On("Do", mock.Anything).
+			Return(createMockResponse(http.StatusOK, ""), nil).
+			Once()
+
+		params := &types.Params{"title": "Custom Title"}
+		err := service.Send("Message with custom title", params)
+
+		require.NoError(t, err)
+		assertRequestContains(t, mockClient, `"weight":"Bolder"`)
+		assertRequestContains(t, mockClient, `"text":"Custom Title"`)
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithColor(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		service := createTestService(
+			t,
+			integrationBase,
+			mockClient,
+		)
+
+		mockClient.On("Do", mock.Anything).
+			Return(createMockResponse(http.StatusOK, ""), nil).
+			Once()
+
+		params := &types.Params{"color": "ff0000"}
+		err := service.Send("Message with color", params)
+
+		require.NoError(t, err)
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithEmptyParameters(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		service := createTestService(
+			t,
+			integrationBase,
+			mockClient,
+		)
+
+		mockClient.On("Do", mock.Anything).
+			Return(createMockResponse(http.StatusOK, ""), nil).
+			Once()
+
+		emptyParams := &types.Params{}
+		err := service.Send("Message with empty params", emptyParams)
+
+		require.NoError(t, err)
+		assertRequestContains(t, mockClient, `"text":"Message with empty params"`)
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithNilParameters(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		service := createTestService(
+			t,
+			integrationBase,
+			mockClient,
+		)
+
+		mockClient.On("Do", mock.Anything).
+			Return(createMockResponse(http.StatusOK, ""), nil).
+			Once()
+
+		err := service.Send("Message with nil params", nil)
+
+		require.NoError(t, err)
+		assertRequestContains(t, mockClient, `"text":"Message with nil params"`)
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithURLParameters(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		mockClient.On("Do", mock.Anything).
+			Return(createMockResponse(http.StatusOK, ""), nil).
+			Once()
+
+		serviceURL := integrationBase + "&title=URLTitle&color=00ff00"
+		service := createTestService(t, serviceURL, mockClient)
+
+		err := service.Send("Message with URL params", nil)
+
+		require.NoError(t, err)
+		assertRequestContains(t, mockClient, `"text":"URLTitle"`)
+		assertRequestContains(t, mockClient, `"weight":"Bolder"`)
+
+		mockClient.AssertExpectations(t)
+	})
+}

--- a/testing/integration/teams/config_test.go
+++ b/testing/integration/teams/config_test.go
@@ -74,6 +74,7 @@ func TestSendWithColor(t *testing.T) {
 		err := service.Send("Message with color", params)
 
 		require.NoError(t, err)
+		assertRequestContains(t, mockClient, `"accentColor":"ff0000"`)
 
 		mockClient.AssertExpectations(t)
 	})

--- a/testing/integration/teams/config_test.go
+++ b/testing/integration/teams/config_test.go
@@ -70,11 +70,12 @@ func TestSendWithColor(t *testing.T) {
 			Return(createMockResponse(http.StatusOK, ""), nil).
 			Once()
 
-		params := &types.Params{"color": "ff0000"}
-		err := service.Send("Message with color", params)
+		params := &types.Params{"color": "attention", "title": "Important"}
+		err := service.Send("Message body", params)
 
 		require.NoError(t, err)
-		assertRequestContains(t, mockClient, `"accentColor":"ff0000"`)
+		assertRequestContains(t, mockClient, `"text":"Important"`)
+		assertRequestContains(t, mockClient, `"color":"attention"`)
 
 		mockClient.AssertExpectations(t)
 	})

--- a/testing/integration/teams/content_test.go
+++ b/testing/integration/teams/content_test.go
@@ -123,7 +123,7 @@ func TestAdaptiveCardStructure(t *testing.T) {
 		require.NoError(t, err)
 
 		assertRequestContains(t, mockClient, `"$schema":"http://adaptivecards.io/schemas/adaptive-card.json"`)
-		assertRequestContains(t, mockClient, `"version":"1.5"`)
+		assertRequestContains(t, mockClient, `"version":"1.2"`)
 		assertRequestContains(t, mockClient, `"contentType":"application/vnd.microsoft.card.adaptive"`)
 
 		mockClient.AssertExpectations(t)

--- a/testing/integration/teams/content_test.go
+++ b/testing/integration/teams/content_test.go
@@ -1,0 +1,131 @@
+package teams_test
+
+import (
+	"net/http"
+	"testing"
+	"testing/synctest"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSendPlainTextMessage(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		service := createTestService(
+			t,
+			integrationBase,
+			mockClient,
+		)
+
+		mockClient.On("Do", mock.Anything).
+			Return(createMockResponse(http.StatusOK, ""), nil).
+			Once()
+
+		err := service.Send("Test plain text message", nil)
+		require.NoError(t, err)
+
+		assertRequestContains(t, mockClient, `"type":"message"`)
+		assertRequestContains(t, mockClient, `"type":"AdaptiveCard"`)
+		assertRequestContains(t, mockClient, `"text":"Test plain text message"`)
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendEmptyMessage(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		service := createTestService(
+			t,
+			integrationBase,
+			mockClient,
+		)
+
+		mockClient.On("Do", mock.Anything).
+			Return(createMockResponse(http.StatusOK, ""), nil).
+			Once()
+
+		err := service.Send("", nil)
+		require.NoError(t, err)
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendMultiLineMessage(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		service := createTestService(
+			t,
+			integrationBase,
+			mockClient,
+		)
+
+		mockClient.On("Do", mock.Anything).
+			Return(createMockResponse(http.StatusOK, ""), nil).
+			Once()
+
+		err := service.Send("Line 1\nLine 2\nLine 3", nil)
+		require.NoError(t, err)
+
+		assertRequestContains(t, mockClient, `"text":"Line 1"`)
+		assertRequestContains(t, mockClient, `"text":"Line 2"`)
+		assertRequestContains(t, mockClient, `"text":"Line 3"`)
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendMessageWithTitleInCard(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		service := createTestService(
+			t,
+			integrationBase+"&title=MyTitle",
+			mockClient,
+		)
+
+		mockClient.On("Do", mock.Anything).
+			Return(createMockResponse(http.StatusOK, ""), nil).
+			Once()
+
+		err := service.Send("Body text", nil)
+		require.NoError(t, err)
+
+		assertRequestContains(t, mockClient, `"text":"MyTitle"`)
+		assertRequestContains(t, mockClient, `"weight":"Bolder"`)
+		assertRequestContains(t, mockClient, `"text":"Body text"`)
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestAdaptiveCardStructure(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		service := createTestService(
+			t,
+			integrationBase,
+			mockClient,
+		)
+
+		mockClient.On("Do", mock.Anything).
+			Return(createMockResponse(http.StatusOK, ""), nil).
+			Once()
+
+		err := service.Send("Test", nil)
+		require.NoError(t, err)
+
+		assertRequestContains(t, mockClient, `"$schema":"http://adaptivecards.io/schemas/adaptive-card.json"`)
+		assertRequestContains(t, mockClient, `"version":"1.5"`)
+		assertRequestContains(t, mockClient, `"contentType":"application/vnd.microsoft.card.adaptive"`)
+
+		mockClient.AssertExpectations(t)
+	})
+}

--- a/testing/integration/teams/errors_test.go
+++ b/testing/integration/teams/errors_test.go
@@ -1,0 +1,105 @@
+package teams_test
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+	"testing/synctest"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nicholas-fedor/shoutrrr/pkg/services/chat/teams"
+)
+
+func TestSendWithHTTPError(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		service := createTestService(
+			t,
+			integrationBase,
+			mockClient,
+		)
+
+		mockClient.On("Do", mock.Anything).
+			Return(nil, errors.New("connection refused")).
+			Once()
+
+		err := service.Send("Test message", nil)
+		require.Error(t, err)
+		require.ErrorIs(t, err, teams.ErrSendFailed)
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWith400BadRequest(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		service := createTestService(
+			t,
+			integrationBase,
+			mockClient,
+		)
+
+		mockClient.On("Do", mock.Anything).
+			Return(createMockResponse(http.StatusBadRequest, ""), nil).
+			Once()
+
+		err := service.Send("Test message", nil)
+		require.Error(t, err)
+		require.ErrorIs(t, err, teams.ErrSendFailedStatus)
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWith500ServerError(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		service := createTestService(
+			t,
+			integrationBase,
+			mockClient,
+		)
+
+		mockClient.On("Do", mock.Anything).
+			Return(createMockResponse(http.StatusInternalServerError, ""), nil).
+			Once()
+
+		err := service.Send("Test message", nil)
+		require.Error(t, err)
+		require.ErrorIs(t, err, teams.ErrSendFailedStatus)
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithEmptyHost(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service := &teams.Service{}
+
+		err := service.Send("Test message", nil)
+		require.Error(t, err)
+		require.ErrorIs(t, err, teams.ErrMissingHost)
+	})
+}
+
+func TestSendWithInvalidWebhookURL(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		serviceURL := "teams://?host=" + url.QueryEscape("https://example.com/invalid")
+		service := createTestService(t, serviceURL, mockClient)
+
+		err := service.Send("Test message", nil)
+		require.Error(t, err)
+
+		mockClient.AssertNotCalled(t, "Do")
+	})
+}

--- a/testing/integration/teams/utils_test.go
+++ b/testing/integration/teams/utils_test.go
@@ -1,0 +1,122 @@
+package teams_test
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+
+	"github.com/nicholas-fedor/shoutrrr/pkg/services/chat/teams"
+)
+
+// MockHTTPClient is a testify mock that implements the teams.HTTPClient interface.
+type MockHTTPClient struct {
+	mock.Mock
+}
+
+// mockLogger is a simple logger implementation for testing.
+type mockLogger struct{}
+
+const workflowURL = "https://prod-00.westus.logic.azure.com:443/workflows/abc123/triggers/manual/paths/invoke?api-version=2016-06-00&sp=/triggers/manual/run&sv=1.0&sig=XXXXXXXX"
+
+func (m *mockLogger) Print(_ ...any)            {}
+func (m *mockLogger) Printf(_ string, _ ...any) {}
+func (m *mockLogger) Println(_ ...any)          {}
+
+// createTestService creates a Teams service instance configured for testing.
+func createTestService(
+	t *testing.T,
+	webhookURL string,
+	httpClients ...teams.HTTPClient,
+) *teams.Service {
+	t.Helper()
+
+	service := &teams.Service{}
+
+	parsedURL, err := url.Parse(webhookURL)
+	if err != nil {
+		t.Fatalf("failed to parse webhook URL: %v", err)
+	}
+
+	err = service.Initialize(parsedURL, &mockLogger{})
+	if err != nil {
+		t.Fatalf("failed to initialize service: %v", err)
+	}
+
+	if len(httpClients) > 0 && httpClients[0] != nil {
+		service.SetHTTPClient(httpClients[0])
+	}
+
+	return service
+}
+
+func (m *MockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	if req.Body != nil {
+		body, err := io.ReadAll(req.Body)
+		if err == nil {
+			req.Body = io.NopCloser(bytes.NewReader(body))
+		}
+	}
+
+	args := m.Called(req)
+
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(*http.Response), args.Error(1)
+}
+
+// createMockResponse creates a mock HTTP response with the given status code, body, and optional headers.
+//
+//nolint:unparam // body and headers are intentionally exposed for callers to use
+func createMockResponse(statusCode int, body string, headers ...map[string]string) *http.Response {
+	resp := &http.Response{
+		StatusCode: statusCode,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+
+	for _, hdrMap := range headers {
+		for k, v := range hdrMap {
+			resp.Header.Set(k, v)
+		}
+	}
+
+	return resp
+}
+
+// assertRequestContains asserts that the HTTP request body contains the expected content.
+func assertRequestContains(t *testing.T, mockClient *MockHTTPClient, expectedContent string) {
+	t.Helper()
+
+	found := false
+
+	for i := range mockClient.Calls {
+		call := &mockClient.Calls[i]
+		if call.Method == "Do" {
+			req := call.Arguments[0].(*http.Request)
+
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				continue
+			}
+
+			req.Body = io.NopCloser(bytes.NewReader(body))
+
+			if strings.Contains(string(body), expectedContent) {
+				found = true
+
+				break
+			}
+		}
+	}
+
+	if !found {
+		t.Errorf("Expected request body to contain %q, but no matching call found", expectedContent)
+	}
+}


### PR DESCRIPTION
Migrate Microsoft Teams service from retired Office 365 Connectors to Power Automate workflow webhooks.

## Problem

Microsoft retired Office 365 Connectors in Teams (May 18-22, 2026), breaking the existing `teams://` service which used `webhook.office.com` URLs and the legacy MessageCard payload format. All existing connector-based webhook URLs are now non-functional.

## Solution

Rewrote the Teams service to use Power Automate workflow incoming webhooks with the Adaptive Card payload format (`{"type":"message","attachments":[...]}`), as documented by Microsoft. The service URL format was simplified from the old five-part UUID decomposition to `teams:?host=<full-workflow-url>`. Added a full integration test suite and updated all documentation.

## Changes

- Rewrote `teams_service.go` — new `HTTPClient` interface for testability, Adaptive Card payload construction, simplified config with `Host`/`Title`/`Color` fields
- Rewrote `teams_config.go` — simplified from 8 fields to 3; URL format changed to `teams:?host=<url>`; `setURL` now distinguishes unknown query params (silently skipped) from real config errors
- Rewrote `teams_types.go` — replaced MessageCard structs with Adaptive Card structs (`adaptivePayload`, `adaptiveAttachment`, `adaptiveCardContent`, `adaptiveBlock`)
- Rewrote `teams_validation.go` — replaced `webhook.office.com` regex with `logic.azure.com/workflows/` pattern supporting sovereign-cloud suffixes (`.azure.us`, `.azure.cn`, `.azure.de`)
- Rewrote `teams_errors.go` — reduced from 12 error sentinels to 4
- Rewrote `teams_test.go` — 13 unit tests covering config round-tripping, Adaptive Card payload, validation, error paths
- Added `testing/integration/teams/` — 16 integration tests (config, content, errors) with mock HTTP client
- Updated `doc.go` — new package documentation referencing Power Automate and Adaptive Cards
- Updated `docs/services/chat/teams/index.md` — new URL format, setup instructions, migration notice, examples
- Updated `docs/services/overview.md` — corrected Teams URL format summary
- Updated `services_test.go` — cross-service test URL updated to new format
- Fixed `router_suite_test.go` — replaced stale Office 365 mock URL with generic service URL
- Removed all dead code: old URL decomposition fields, `BuildWebhookURL`, `ParseAndVerifyWebhookURL`, `verifyWebhookParts`, `SetFromWebhookURL`, `ConfigFromWebhookURL`, `WebhookParts`, `GetServiceURLFromCustom`, old validation regexes, old error constants (net reduction ~370 lines)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Legacy Office 365 Connector / MessageCard webhook formats removed; only Power Automate workflow webhooks (teams://?host=...) are supported.

* **Documentation**
  * Teams docs rewritten to guide Power Automate “When a Teams webhook request is received” setup and the new teams://?host=... URL format.

* **New Features**
  * Messages now use Adaptive Cards and support optional title and color parameters.

* **Tests**
  * New unit and integration tests for initialization, sending, error handling, and payload content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nicholas-fedor/shoutrrr/pull/887?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->