### PR TITLE
docs: Ntfy: fix URL format (no slash before the parameters)

### DIFF
--- a/docs/services/push/ntfy/index.md
+++ b/docs/services/push/ntfy/index.md
@@ -5,7 +5,7 @@ Upstream docs: <https://docs.ntfy.sh/publish/>
 ## URL Format
 
 !!! info ""
-    ntfy://__`host`__/__`topic`__/?priority=__`priority`__&tags=__`tag1`__,__`tag2`__&title=__`title`__
+    ntfy://__`host`__/__`topic`__?priority=__`priority`__&tags=__`tag1`__,__`tag2`__&title=__`title`__
 
 --8<-- "docs/services/push/ntfy/config.md"
 
@@ -54,7 +54,7 @@ Commonly used parameters can be added as query parameters to customize notificat
 
 !!! example "High-priority notification with tags"
     ```uri
-    ntfy://ntfy.sh/alerts/?priority=5&tags=warning,fire&title=System+Alert
+    ntfy://ntfy.sh/alerts?priority=5&tags=warning,fire&title=System+Alert
     ```
 
 !!! note
@@ -85,15 +85,15 @@ Ntfy supports two TLS-related configuration options to handle different security
 
 !!! example "With parameters"
     ```uri
-    ntfy://ntfy.sh/updates/?priority=4&tags=info,computer&title=Server+Update
+    ntfy://ntfy.sh/updates?priority=4&tags=info,computer&title=Server+Update
     ```
 
 !!! example "Delayed notification"
     ```uri
-    ntfy://ntfy.sh/reminders/?delay=1h&title=Meeting+in+1+hour
+    ntfy://ntfy.sh/reminders?delay=1h&title=Meeting+in+1+hour
     ```
 
 !!! example "With action button"
     ```uri
-    ntfy://ntfy.sh/tasks/?actions=[{"action":"view","label":"Open Dashboard","url":"https://dashboard.example.com"}]&title=Task+Completed
+    ntfy://ntfy.sh/tasks?actions=[{"action":"view","label":"Open Dashboard","url":"https://dashboard.example.com"}]&title=Task+Completed
     ```


### PR DESCRIPTION
I found an issue with Ntfy URLs:
> It seems Ntfy **does NOT use a slash `/` before the 'parameters'**

URLs should be this:
```
ntfy.sh/topic?tags=alert
```

NOT this:
```
ntfy.sh/topic/?tags=alert
```

I changed the docs to reflect that

<br>

_If I'm mistaken, please correct me :)_

## Logs + environment

### My production  environment:
- **Ntfy**
   - Version: `v2.14`
   - self-hosted (Docker)
- **[Scrutiny](https://github.com/AnalogJ/scrutiny/blob/master/docs/TROUBLESHOOTING_NOTIFICATIONS.md)** (uses Shoutrrr)
   - Version: `dev-0.8.2`

### Logs

With the `/`, I was getting `not found` errors from the server. Logs from [Scrutiny](https://github.com/AnalogJ/scrutiny/blob/master/docs/TROUBLESHOOTING_NOTIFICATIONS.md)'s Docker container:
```
scrutiny  | time="2026-05-30T20:33:44Z" level=error msg="One or more errors occurred while sending notifications for ntfy://my-ntfy-url.domain.com/topic-name/?tags=supermicro-x11-media&click=\"https://url-to-open.domain.com\"&actions=[{\"action\":\"view\",\"label\":\"Open Scrutiny\",\"url\":\"https://url-to-open.domain.com\"}]:" type=web
scrutiny  | time="2026-05-30T20:33:44Z" level=error msg="[failed to send ntfy notification: server response: page not found (40401)]" type=web
scrutiny  | time="2026-05-30T20:33:44Z" level=error msg="One or more notifications failed to send successfully. See logs for more information." type=web
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ntfy service documentation to correct URL format specifications and examples, ensuring accurate and consistent query parameter syntax references throughout all provided configuration guides.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nicholas-fedor/shoutrrr/pull/889?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->