### PR TITLE
fix(teams): expand webhook URL validation to support Power Automate endpoints

### DIFF
--- a/pkg/services/chat/teams/teams_test.go
+++ b/pkg/services/chat/teams/teams_test.go
@@ -159,6 +159,8 @@ var _ = ginkgo.Describe("the teams service", func() {
 				"https://prod-00.westus.logic.azure.us/workflows/abc123/triggers/manual/paths/invoke",
 				"https://prod-00.westus.logic.azure.cn/workflows/abc123/triggers/manual/paths/invoke",
 				"https://prod-00.westus.logic.azure.de/workflows/abc123/triggers/manual/paths/invoke",
+				"https://default.environment.api.powerplatform.com/powerautomate/automations/direct/workflows/abc123/triggers/manual/paths/invoke?api-version=1&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=XXXXXXXX",
+				"https://prefix.environment.environment.api.powerplatform.com:443/powerautomate/automations/direct/workflows/abc123/triggers/manual/paths/invoke",
 			}
 			for _, u := range validURLs {
 				err := ValidateWebhookURL(u)

--- a/pkg/services/chat/teams/teams_validation.go
+++ b/pkg/services/chat/teams/teams_validation.go
@@ -6,7 +6,7 @@ import (
 )
 
 var workflowURLValidator = regexp.MustCompile(
-	`^https://[a-zA-Z0-9][a-zA-Z0-9.-]*\.logic\.azure(?:\.[a-z]{2,})?(:\d+)?/workflows/`,
+	`^https://[a-zA-Z0-9][a-zA-Z0-9.-]*\.(?:logic\.azure(?:\.[a-z]{2,})?|environment\.api\.powerplatform\.com)(:\d+)?/(?:powerautomate/automations/direct/)?workflows/`,
 )
 
 // ValidateWebhookURL ensures the webhook URL matches the Power Automate workflow pattern.

--- a/pkg/services/chat/teams/teams_validation.go
+++ b/pkg/services/chat/teams/teams_validation.go
@@ -6,7 +6,8 @@ import (
 )
 
 var workflowURLValidator = regexp.MustCompile(
-	`^https://[a-zA-Z0-9][a-zA-Z0-9.-]*\.(?:logic\.azure(?:\.[a-z]{2,})?|environment\.api\.powerplatform\.com)(:\d+)?/(?:powerautomate/automations/direct/)?workflows/`,
+	`^https://[a-zA-Z0-9][a-zA-Z0-9.-]*\.logic\.azure(?:\.[a-z]{2,})?(:\d+)?/(?:powerautomate/automations/direct/)?workflows/|` +
+		`^https://[a-zA-Z0-9][a-zA-Z0-9.-]*\.environment\.api\.powerplatform\.com(:\d+)?/powerautomate/automations/direct/workflows/`,
 )
 
 // ValidateWebhookURL ensures the webhook URL matches the Power Automate workflow pattern.


### PR DESCRIPTION
This PR corrects Shoutrrr's URL validation for the Teams service to include the new Power Platform domain.

## Problem

Microsoft is migrating Power Automate HTTP and Teams Webhook triggers from the legacy `*.logic.azure.com` domain to the new `*.environment.api.powerplatform.com` domain. Webhook URLs generated by newer Power Automate workflows use the new domain and a `/powerautomate/automations/direct/workflows/` path prefix, which Shoutrrr rejects with "Invalid webhook URL format".

## Solution

Updated the webhook URL validation regex in `teams_validation.go` to accept both the legacy Logic Apps domain and the new Power Platform domain, with optional port and path prefix matching.

## Changes

- `teams_validation.go`: Updated `workflowURLValidator` regex to match `environment.api.powerplatform.com` as an alternative domain and `/powerautomate/automations/direct/` as an optional path prefix
- `teams_test.go`: Added two test cases for Power Platform webhook URLs (with and without port)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Teams webhook URL validation to accept additional Power Platform URL formats and variations, including broader domain patterns and optional port numbers.
  * Expands accepted webhook URL cases to reduce false rejections when configuring Teams integrations, while preserving existing error handling for invalid URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->