### PR TITLE
fix(teams): accept 202 Accepted as valid response status code

### DIFF
--- a/pkg/services/chat/teams/teams_service.go
+++ b/pkg/services/chat/teams/teams_service.go
@@ -185,7 +185,7 @@ func (s *Service) doSend(config *Config, message string) error {
 
 	defer func() { _ = res.Body.Close() }()
 
-	if res.StatusCode != http.StatusOK {
+	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusAccepted {
 		return fmt.Errorf("%w: %s", ErrSendFailedStatus, res.Status)
 	}
 

--- a/pkg/services/chat/teams/teams_test.go
+++ b/pkg/services/chat/teams/teams_test.go
@@ -47,6 +47,20 @@ var _ = ginkgo.Describe("the teams service", func() {
 			err = service.Send("Message", nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
+		ginkgo.It("should not report an error if the server responds with 202 Accepted", func() {
+			serviceURL, _ := url.Parse(serviceURLBase)
+			err = service.Initialize(serviceURL, logger)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			httpmock.RegisterResponder(
+				"POST",
+				workflowURL,
+				httpmock.NewStringResponder(http.StatusAccepted, ""),
+			)
+
+			err = service.Send("Message", nil)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
 		ginkgo.It("should report an error if the server returns non-200", func() {
 			serviceURL, _ := url.Parse(serviceURLBase)
 			err = service.Initialize(serviceURL, logger)

--- a/testing/integration/teams/errors_test.go
+++ b/testing/integration/teams/errors_test.go
@@ -35,6 +35,27 @@ func TestSendWithHTTPError(t *testing.T) {
 	})
 }
 
+func TestSendWith202Accepted(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		service := createTestService(
+			t,
+			integrationBase,
+			mockClient,
+		)
+
+		mockClient.On("Do", mock.Anything).
+			Return(createMockResponse(http.StatusAccepted, ""), nil).
+			Once()
+
+		err := service.Send("Test message", nil)
+		require.NoError(t, err)
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
 func TestSendWith400BadRequest(t *testing.T) {
 	t.Parallel()
 	synctest.Test(t, func(t *testing.T) {


### PR DESCRIPTION
This PR fixes the Teams service to accept 202 Accepted as a valid response status code.

## Problem

Microsoft Power Automate workflow webhooks return 202 Accepted on successful delivery, but the Teams service only recognized 200 OK. This causes every successful notification to be reported as a failure: "failed to send notification to teams, response status code unexpected: 202 Accepted".

## Solution

Updated the status code check in doSend() to accept both 200 OK and 202 Accepted as successful responses.

## Changes

- pkg/services/chat/teams/teams_service.go — Status check now allows http.StatusAccepted (202) in addition to http.StatusOK (200)
- pkg/services/chat/teams/teams_test.go — Added unit test verifying 202 is treated as success
- testing/integration/teams/errors_test.go — Added integration test for 202 Accepted response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Microsoft Teams Power Automate webhook integration now treats HTTP 202 Accepted responses as successful status codes, in addition to the previously supported 200 OK responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->