### PR TITLE
ci: wire publish-docs into release-stable workflow

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -1,7 +1,13 @@
 name: Publish Documentation
 
 on:
-  workflow_dispatch: {}
+  workflow_call:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to deploy (e.g., v0.16.0). Leave empty for dev."
+        required: false
+        type: string
   push:
     branches: [main]
     paths:
@@ -83,9 +89,13 @@ jobs:
         id: mike
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           if [[ "${{ github.event_name }}" == "release" ]]; then
             echo "version=${TAG_NAME}" >> "$GITHUB_OUTPUT"
+            echo "aliases=latest" >> "$GITHUB_OUTPUT"
+          elif [[ -n "${INPUT_VERSION}" ]]; then
+            echo "version=${INPUT_VERSION}" >> "$GITHUB_OUTPUT"
             echo "aliases=latest" >> "$GITHUB_OUTPUT"
           else
             echo "version=dev" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -2,6 +2,11 @@ name: Publish Documentation
 
 on:
   workflow_call:
+    inputs:
+      version:
+        description: "Version to deploy (e.g., v0.16.0). Leave empty for dev."
+        required: false
+        type: string
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -46,3 +46,14 @@ jobs:
     permissions:
       contents: read
     uses: ./.github/workflows/update-go-docs.yaml
+
+  publish-docs:
+    name: Publish Documentation
+    needs: build
+    if: ${{ !inputs.DRY_RUN }}
+    permissions:
+      contents: write
+      actions: read
+    uses: ./.github/workflows/publish-docs.yaml
+    with:
+      version: ${{ github.ref_name }}


### PR DESCRIPTION
This PR adds back the publishing of versioned documentation during the stable release process.

## Problem

The latest refactoring of the CI pipelines removed the publishing of versioned documentation during the release process. This fails when stable releases are published by GoReleaser, rather than via the GitHub website.

## Solution

Call the existing publish docs workflow at the end of the stable release workflow. This allows for passing the version reference for Mike to handle proper versioning.

A manual dispatch option is also added to help with manually running the workflow, if necessary.

## Changes

- Convert `publish-docs.yaml` to a reusable workflow via `workflow_call` while keeping `workflow_dispatch` with an optional `version` input
- Add `version` input handling in the `mike` step to deploy with `latest` alias when a version is provided
- Invoke `publish-docs` as a job in `release-stable.yaml` after `build`, passing the release tag as the version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Documentation publishing workflow now supports being invoked by other workflows and accepts an optional version input to control the published version.
  * Stable release process now includes automatic documentation deployment, triggering the publish workflow with the release version when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->