### PR TITLE
docs(playground): fix smtp port field error

### DIFF
--- a/docs/playground/wasm/generator_test.go
+++ b/docs/playground/wasm/generator_test.go
@@ -56,6 +56,24 @@ func TestGenerateURLString(t *testing.T) {
 			configJSON: `{}`,
 			wantURL:    "logger://",
 		},
+		{
+			name:       "generates smtp URL with host and port",
+			service:    "smtp",
+			configJSON: `{"Host":"smtp.example.com","Port":"587","FromAddress":"sender@example.com","ToAddresses":"recipient@example.com"}`,
+			wantSubstr: []string{"smtp://", "smtp.example.com:587"},
+		},
+		{
+			name:        "returns error for invalid port value",
+			service:     "smtp",
+			configJSON:  `{"Host":"smtp.example.com","Port":"notanumber","FromAddress":"sender@example.com","ToAddresses":"recipient@example.com"}`,
+			wantErrResp: true,
+		},
+		{
+			name:        "returns error for port exceeding uint16 max",
+			service:     "smtp",
+			configJSON:  `{"Host":"smtp.example.com","Port":"65536","FromAddress":"sender@example.com","ToAddresses":"recipient@example.com"}`,
+			wantErrResp: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/docs/playground/wasm/helpers.go
+++ b/docs/playground/wasm/helpers.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -24,6 +25,9 @@ var errFieldNotSettable = errors.New("field not settable")
 
 // errInvalidBoolValue is returned when a bool field receives an invalid value.
 var errInvalidBoolValue = errors.New("invalid bool value")
+
+// errInvalidUintValue is returned when a uint field receives an unparseable value.
+var errInvalidUintValue = errors.New("invalid uint value")
 
 // errUnsupportedFieldType is returned when a field type is unsupported for string assignment.
 var errUnsupportedFieldType = errors.New("unsupported field type for string assignment")
@@ -106,9 +110,12 @@ func getEnumNames(ef types.EnumFormatter) []string {
 }
 
 // setFieldFromString sets configValue[fieldName] to value using reflection.
-// Supports string and bool field types. Bool values are parsed via
-// format.ParseBool(). Returns an error if the field is invalid, cannot be set,
-// or the value cannot be parsed for the field type.
+// Supports string, bool, and unsigned integer field types. Bool values are
+// parsed via format.ParseBool(). Unsigned integers are parsed via
+// strconv.ParseUint using the field's bit size. Returns an error if the field
+// is invalid, cannot be set, or the value cannot be parsed for the field type.
+//
+//nolint:exhaustive // uint kinds handled; all others fallback to default.
 func setFieldFromString(configValue reflect.Value, fieldName, value string) error {
 	field := configValue.FieldByName(fieldName)
 	if !field.IsValid() {
@@ -119,7 +126,6 @@ func setFieldFromString(configValue reflect.Value, fieldName, value string) erro
 		return fmt.Errorf("%w: %q", errFieldNotSettable, fieldName)
 	}
 
-	//nolint:exhaustive // Only handling string and bool fields.
 	switch field.Kind() {
 	case reflect.String:
 		field.SetString(value)
@@ -132,6 +138,17 @@ func setFieldFromString(configValue reflect.Value, fieldName, value string) erro
 		}
 
 		field.SetBool(bv)
+
+		return nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		bits := field.Type().Bits()
+
+		parsed, err := strconv.ParseUint(value, 10, bits)
+		if err != nil {
+			return fmt.Errorf("%w: %q for field %q: %w", errInvalidUintValue, value, fieldName, err)
+		}
+
+		field.SetUint(parsed)
 
 		return nil
 	default:


### PR DESCRIPTION
This PR resolves an error in the Shoutrrr Docs Playground when a user sets a Port value for SMTP (or any service with a uint Port field). 

## Problem

The Playground UI generates a form for all config fields including `Port`, but when the user enters a port value for SMTP, URL generation fails with:

```text
Error: invalid config "Port"="587": not a valid config key
```

The SMTP `Port` field has `url:"Port"` (structural URL component) but no `key:` tag, so `PropKeyResolver.Set()` rejects it. The fallback `setFieldFromString` only supported `string` and `bool` types, not `uint16`.

## Solution

Extended `setFieldFromString` in the WASM playground to support unsigned integer field types (`uint`, `uint8`, `uint16`, `uint32`, `uint64`) using `strconv.ParseUint` with the field's bit size. This is a generic fix — any service with a `Port` (or other uint) field that has a `url:` tag but no `key:` tag now works in the Playground.

## Changes

- `docs/playground/wasm/helpers.go` — added uint parsing support to `setFieldFromString`
- `docs/playground/wasm/generator_test.go` — added test cases for valid port, non-numeric port, and port overflow (>65535)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of numeric values in the playground input flow, including clearer errors for invalid or out-of-range port values.
  * Generated service URLs now correctly support `smtp` entries with the expected `smtp://` format and `host:port` output.
* **Tests**
  * Added coverage for valid and invalid `smtp` URL generation cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->