### PR TITLE
docs(README): correct binary install commands for Linux and macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,13 @@ Install the latest release binary to `$HOME/go/bin` (ensure it's in your `PATH`)
 - **Linux (amd64):**
 
   ```bash
-  mkdir -p $HOME/go/bin && curl -L $(curl -s https://api.github.com/repos/nicholas-fedor/shoutrrr/releases/latest | grep -o 'https://[^"]*linux_amd64[^"]*\.tar\.gz') | tar -xz --strip-components=1 -C $HOME/go/bin shoutrrr
+   mkdir -p $HOME/go/bin && curl -L $(curl -s https://api.github.com/repos/nicholas-fedor/shoutrrr/releases/latest | grep -o 'https://[^"]*linux_amd64[^"]*\.tar\.gz"' | grep -o 'https://[^"]*' | head -n1) | tar -xz -C $HOME/go/bin shoutrrr
   ```
 
 - **macOS (amd64):**
 
   ```bash
-  mkdir -p $HOME/go/bin && curl -L $(curl -s https://api.github.com/repos/nicholas-fedor/shoutrrr/releases/latest | grep -o 'https://[^"]*darwin_amd64[^"]*\.tar\.gz') | tar -xz --strip-components=1 -C $HOME/go/bin shoutrrr
+   mkdir -p $HOME/go/bin && curl -L $(curl -s https://api.github.com/repos/nicholas-fedor/shoutrrr/releases/latest | grep -o 'https://[^"]*macOS_amd64[^"]*\.tar\.gz"' | grep -o 'https://[^"]*' | head -n1) | tar -xz -C $HOME/go/bin shoutrrr
   ```
 
 > [!Note]


### PR DESCRIPTION
This PR resolves a minor issue with the README's 1-line binary install scripts for Linux and macOS.

## Problem

Issue #1053 reported that the Linux install one-liner fails with:
`curl: (23) Failure writing output to destination, passed 16375 returned 0`

This is caused by the `grep -o` pattern returning two URLs instead of one, because the `.sbom.json` entries contain a `.tar.gz` substring that the regex still matches. The SBOM URL is truncated in the output rather than the full canonical URL, corrupting the input stream. Independently, the macOS command used `darwin_amd64` which does not match any released asset.

## Solution

Anchor the regex output to a trailing literal `.tar.gz"` so that embedded SBOM matches are excluded, then extract only the URL portion with a second `grep -o 'https://[^"]*' | head -n1` to guarantee exactly one URL is passed into `curl`. Update the macOS command to use the actual release asset name `macOS_amd64`.

## Changes

- restrict linux/macOS `grep` output to literal terminal `.tar.gz"` matches to skip `.tar.gz.sbom.json` partial matches
- pipe through a second `grep -o 'https://[^"]*' | head -n1` to collapse any duplicates into a single URL
- rename macOS asset selector from `darwin_amd64` to `macOS_amd64` to match published release assets
- remove unnecessary `--strip-components=1` from linux tar extraction; current tarballs contain files at the root

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Linux amd64 binary installation instructions to use a more reliable download-and-extract command.
  * Added a step to create the destination directory before installing.
  * Adjusted the archive extraction process to place the binary in the expected location more directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->