### PR TITLE
docs: correct binary install commands for Linux and macOS

### DIFF
--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -27,13 +27,13 @@ The following scripts install the latest release binary to the user's `$HOME/go/
 === "Linux (amd64)"
 
     ```bash title="Linux (amd64) Installation"
-    mkdir -p $HOME/go/bin && curl -L $(curl -s https://api.github.com/repos/nicholas-fedor/shoutrrr/releases/latest | grep -o 'https://[^"]*linux_amd64[^"]*\.tar\.gz') | tar -xz --strip-components=1 -C $HOME/go/bin shoutrrr
+    mkdir -p $HOME/go/bin && curl -L $(curl -s https://api.github.com/repos/nicholas-fedor/shoutrrr/releases/latest | grep -o 'https://[^"]*linux_amd64[^"]*\.tar\.gz"' | grep -o 'https://[^"]*' | head -n1) | tar -xz -C $HOME/go/bin shoutrrr
     ```
 
 === "macOS (amd64)"
 
     ```bash title="macOS (amd64) Installation"
-    mkdir -p $HOME/go/bin && curl -L $(curl -s https://api.github.com/repos/nicholas-fedor/shoutrrr/releases/latest | grep -o 'https://[^"]*darwin_amd64[^"]*\.tar\.gz') | tar -xz --strip-components=1 -C $HOME/go/bin shoutrrr
+    mkdir -p $HOME/go/bin && curl -L $(curl -s https://api.github.com/repos/nicholas-fedor/shoutrrr/releases/latest | grep -o 'https://[^"]*macOS_amd64[^"]*\.tar\.gz"' | grep -o 'https://[^"]*' | head -n1) | tar -xz -C $HOME/go/bin shoutrrr
     ```
 <!-- markdownlint-restore -->
 !!! Note


### PR DESCRIPTION
This PR updates the Shoutrrr website with the corrected 1-line installation scripts for Linux and macOS.

## Problem

Issue #1053 reported that the Linux install one-liner fails with:
`curl: (23) Failure writing output to destination, passed 16375 returned 0`

This is caused by the `grep -o` pattern returning two URLs instead of one, because the `.sbom.json` entries contain a `.tar.gz` substring that the regex still matches. The SBOM URL is truncated in the output rather than the full canonical URL, corrupting the input stream. Independently, the macOS command used `darwin_amd64` which does not match any released asset.

## Solution

Anchor the regex output to a trailing literal `.tar.gz"` so that embedded SBOM matches are excluded, then extract only the URL portion with a second `grep -o 'https://[^"]*' | head -n1` to guarantee exactly one URL is passed into `curl`. Update the macOS command to use the actual release asset name `macOS_amd64`.

## Changes

- restrict linux/macOS `grep` output to literal terminal `.tar.gz"` matches to skip `.tar.gz.sbom.json` partial matches
- pipe through a second `grep -o 'https://[^"]*' | head -n1` to collapse any duplicates into a single URL
- rename macOS asset selector from `darwin_amd64` to `macOS_amd64` to match published release assets
- remove unnecessary `--strip-components=1` from linux tar extraction; current tarballs contain files at the root

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Linux and macOS installation steps for GitHub Release Binary downloads.
  * Refined the archive extraction command used in the install instructions.
  * Adjusted the macOS download matching pattern to better align with the release asset naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->