### PR TITLE
ci(lint-commit): skip bot-generated commits

### DIFF
--- a/.github/workflows/lint-commit.yml
+++ b/.github/workflows/lint-commit.yml
@@ -9,6 +9,7 @@ jobs:
   lint:
     name: Lint Commit Message
     runs-on: ubuntu-latest
+    if: github.event.pull_request.user.type != 'Bot'
     steps:
       - name: Harden the Runner (Step Security)
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0


### PR DESCRIPTION
This PR adds a conditional statement to the workflow for linting commit messages.

## Problem

The workflow runs on all PR's, including those generated by Renovate or GitHub Actions (i.e. changelog updates).

## Solution

Add a job-level conditional statement to identify and skip if the PR was created using a bot account.

## Changes

- Add job condition to skip if pr is bot-generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Commit message linting now skips pull requests created by automated bot accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->