### PR TITLE
fix(teams): accept workflow URLs with routing segments before workflows/

### DIFF
--- a/pkg/services/chat/teams/teams_test.go
+++ b/pkg/services/chat/teams/teams_test.go
@@ -175,6 +175,8 @@ var _ = ginkgo.Describe("the teams service", func() {
 				"https://prod-00.westus.logic.azure.de/workflows/abc123/triggers/manual/paths/invoke",
 				"https://default.environment.api.powerplatform.com/powerautomate/automations/direct/workflows/abc123/triggers/manual/paths/invoke?api-version=1&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=XXXXXXXX",
 				"https://prefix.environment.environment.api.powerplatform.com:443/powerautomate/automations/direct/workflows/abc123/triggers/manual/paths/invoke",
+				"https://default0123456789abcdef.00.environment.api.powerplatform.com:443/powerautomate/automations/direct/cu/04/workflows/abc123/triggers/manual/paths/invoke?api-version=1&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=XXXXXXXX",
+				"https://prod-00.westus.logic.azure.com/powerautomate/automations/direct/cu/04/workflows/abc123/triggers/manual/paths/invoke",
 			}
 			for _, u := range validURLs {
 				err := ValidateWebhookURL(u)
@@ -185,6 +187,7 @@ var _ = ginkgo.Describe("the teams service", func() {
 		ginkgo.It("should reject invalid URLs", func() {
 			invalidURLs := []string{
 				"https://example.com/webhook",
+				"https://default.environment.api.powerplatform.com/powerautomate/automations/workflows/abc123/triggers/manual/paths/invoke",
 				"",
 			}
 			for _, u := range invalidURLs {

--- a/pkg/services/chat/teams/teams_validation.go
+++ b/pkg/services/chat/teams/teams_validation.go
@@ -5,9 +5,13 @@ import (
 	"regexp"
 )
 
+// workflowURLValidator matches Power Automate workflow webhook URLs.
+// Newer URLs issued by Microsoft can include routing segments between
+// "direct/" and "workflows/" (e.g. ".../automations/direct/cu/04/workflows/..."),
+// so optional intermediate path segments are allowed before "workflows/".
 var workflowURLValidator = regexp.MustCompile(
-	`^https://[a-zA-Z0-9][a-zA-Z0-9.-]*\.logic\.azure(?:\.[a-z]{2,})?(:\d+)?/(?:powerautomate/automations/direct/)?workflows/|` +
-		`^https://[a-zA-Z0-9][a-zA-Z0-9.-]*\.environment\.api\.powerplatform\.com(:\d+)?/powerautomate/automations/direct/workflows/`,
+	`^https://[a-zA-Z0-9][a-zA-Z0-9.-]*\.logic\.azure(?:\.[a-z]{2,})?(:\d+)?/(?:powerautomate/automations/direct/(?:[A-Za-z0-9-]+/)*)?workflows/|` +
+		`^https://[a-zA-Z0-9][a-zA-Z0-9.-]*\.environment\.api\.powerplatform\.com(:\d+)?/powerautomate/automations/direct/(?:[A-Za-z0-9-]+/)*workflows/`,
 )
 
 // ValidateWebhookURL ensures the webhook URL matches the Power Automate workflow pattern.


### PR DESCRIPTION
## TLDR

Microsoft now issues Teams workflow webhook URLs with extra path segments between `direct/` and `workflows/`. The Teams validator does not allow them, so every send fails with `invalid webhook URL format`.

URL Microsoft issues now (redacted):

```
https://default<guid>.<xx>.environment.api.powerplatform.com:443/powerautomate/automations/direct/cu/04/workflows/<id>/triggers/manual/paths/invoke?api-version=1&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=<sig>
```

## Change

- Allow optional routing segments before `workflows/` in both host variants of `workflowURLValidator`.
- Tests: added the new URL shape for both the `powerplatform.com` and `logic.azure` variants to the valid list, and a missing-`direct` URL to the invalid list.

## Verification

- `go test ./pkg/services/chat/teams/...` passes, `gofmt` clean.
- Verified against a real webhook: on v0.16.2 the URL above fails validation; the same URL with `/cu/04` manually stripped sends successfully (`Notification sent`, card delivered). Only the validator rejects the new shape; the endpoint itself accepts it.

Also affects watchtower v1.20.1 (nicholas-fedor/watchtower), which vendors shoutrrr v0.16.2 and logs `error="invalid webhook URL format" service=teams url="teams:"` for these URLs via both the notification-url and legacy msteams configuration paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated webhook URL validation to support newer Microsoft Power Automate URLs with additional routing segments.
  - Preserved support for existing webhook URL formats and validation behavior.

- **Tests**
  - Expanded validation coverage with additional valid and invalid webhook URL examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->