### PR TITLE
fix(teams): allow optional routing segments in webhook URL validation

### DIFF
--- a/pkg/services/chat/teams/teams_test.go
+++ b/pkg/services/chat/teams/teams_test.go
@@ -175,6 +175,8 @@ var _ = ginkgo.Describe("the teams service", func() {
 				"https://prod-00.westus.logic.azure.de/workflows/abc123/triggers/manual/paths/invoke",
 				"https://default.environment.api.powerplatform.com/powerautomate/automations/direct/workflows/abc123/triggers/manual/paths/invoke?api-version=1&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=XXXXXXXX",
 				"https://prefix.environment.environment.api.powerplatform.com:443/powerautomate/automations/direct/workflows/abc123/triggers/manual/paths/invoke",
+				"https://default0123456789abcdef.00.environment.api.powerplatform.com:443/powerautomate/automations/direct/cu/04/workflows/abc123/triggers/manual/paths/invoke?api-version=1&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=XXXXXXXX",
+				"https://prod-00.westus.logic.azure.com/powerautomate/automations/direct/cu/04/workflows/abc123/triggers/manual/paths/invoke",
 			}
 			for _, u := range validURLs {
 				err := ValidateWebhookURL(u)
@@ -185,6 +187,7 @@ var _ = ginkgo.Describe("the teams service", func() {
 		ginkgo.It("should reject invalid URLs", func() {
 			invalidURLs := []string{
 				"https://example.com/webhook",
+				"https://default.environment.api.powerplatform.com/powerautomate/automations/workflows/abc123/triggers/manual/paths/invoke",
 				"",
 			}
 			for _, u := range invalidURLs {

--- a/pkg/services/chat/teams/teams_validation.go
+++ b/pkg/services/chat/teams/teams_validation.go
@@ -5,9 +5,24 @@ import (
 	"regexp"
 )
 
+// workflowURLValidator matches the Power Automate workflow webhook URL formats
+// documented by Microsoft for the "When a Teams webhook request is received"
+// trigger.
+//
+// Two host patterns are accepted:
+//   - Legacy Logic Apps: https://*.logic.azure.com/workflows/...
+//   - Current Power Platform: https://*.environment.api.powerplatform.com/powerautomate/automations/direct/.../workflows/...
+//
+// The Power Platform path may contain optional routing segments between
+// "direct/" and "workflows/" (e.g. ".../direct/cu/04/workflows/..."), which
+// Microsoft inserts when routing through the Power Platform ingress gateway.
+//
+// References:
+//   - https://learn.microsoft.com/en-us/troubleshoot/power-platform/power-automate/flow-run-issues/triggers-troubleshoot?tabs=new-designer#changes-to-http-or-teams-webhook-trigger-flows
+//   - https://learn.microsoft.com/en-us/power-automate/overview
 var workflowURLValidator = regexp.MustCompile(
-	`^https://[a-zA-Z0-9][a-zA-Z0-9.-]*\.logic\.azure(?:\.[a-z]{2,})?(:\d+)?/(?:powerautomate/automations/direct/)?workflows/|` +
-		`^https://[a-zA-Z0-9][a-zA-Z0-9.-]*\.environment\.api\.powerplatform\.com(:\d+)?/powerautomate/automations/direct/workflows/`,
+	`^https://[a-zA-Z0-9][a-zA-Z0-9.-]*\.logic\.azure(?:\.[a-z]{2,})?(:\d+)?/(?:powerautomate/automations/direct/(?:[A-Za-z0-9-]+/)*)?workflows/|` +
+		`^https://[a-zA-Z0-9][a-zA-Z0-9.-]*\.environment\.api\.powerplatform\.com(:\d+)?/powerautomate/automations/direct/(?:[A-Za-z0-9-]+/)*workflows/`,
 )
 
 // ValidateWebhookURL ensures the webhook URL matches the Power Automate workflow pattern.


### PR DESCRIPTION
This PR updates the Teams webhook URL validator to accept the newer Power Automate trigger URL shape that Microsoft now issues, which includes optional routing segments between `direct/` and `workflows/` (e.g. `/direct/cu/04/workflows/`). Without this change, every send to those URLs fails with `invalid webhook URL format` even though the endpoint itself accepts them.

## Problem

Microsoft inserts intermediate path segments in Power Automate webhook URLs when routing through the Power Platform ingress gateway. The existing `workflowURLValidator` regex required an exact `direct/workflows/` sequence, so URLs like `.../direct/cu/04/workflows/abc123/...` were rejected client-side before any HTTP request was made.

## Solution

Updated the regex in both host-pattern alternatives to allow zero or more optional routing segments (`[A-Za-z0-9-]+/`) between `direct/` and `workflows/`. Added test coverage for the new shape on both the `logic.azure` and `powerplatform.com` variants, plus a negative case confirming that URLs missing the `direct` segment are still rejected.

## Changes

- Update workflow URL regex to accept intermediate path segments between "direct/" and "workflows/"
- Add test cases for newer Power Automate webhook URL formats
- Add invalid URL test case for URLs missing required path segments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for Microsoft Teams and Power Automate webhook URLs.
  * Added support for additional documented workflow URL formats while continuing to reject invalid Power Platform URLs.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->