### PR TITLE
fix(router): preserve original service initialization error

### DIFF
--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -31,7 +31,6 @@ var (
 	ErrParseURLFailed         = errors.New("failed to parse URL")
 	ErrSendFailed             = errors.New("failed to send message")
 	ErrCustomURLConversion    = errors.New("failed to convert custom URL")
-	ErrInitializeFailed       = errors.New("failed to initialize service")
 )
 
 // New creates a new service router using the specified logger and service URLs.
@@ -253,7 +252,7 @@ func (r *ServiceRouter) initService(rawURL string) (types.Service, error) {
 
 	err = service.Initialize(serviceURL, r.logger)
 	if err != nil {
-		return service, fmt.Errorf("%s: %w", scheme, ErrInitializeFailed)
+		return service, fmt.Errorf("%s: %w", scheme, err)
 	}
 
 	// Inject custom HTTP client if provided and the service supports it.


### PR DESCRIPTION
This PR fixes the router to preserve the original error from service.Initialize instead of discarding it behind a generic sentinel.

## Problem

When a service failed to initialize, the router replaced the real error with `ErrInitializeFailed`. Users saw only `<scheme>: failed to initialize service` with no information about the actual cause.

## Solution

Wrap the original error from `service.Initialize` so the full error chain is preserved.

## Changes

- Changed the `initService` error wrapping to use the original error
- Removed the unused `ErrInitializeFailed` sentinel error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Service initialization failures now report the underlying error, including the affected service scheme, for clearer troubleshooting.
  * Removed the generic initialization failure error in favor of more specific error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->