### PR TITLE
feat(ntfy): add markdown support

### DIFF
--- a/pkg/services/push/ntfy/doc.go
+++ b/pkg/services/push/ntfy/doc.go
@@ -33,6 +33,7 @@
 //   - delay: timestamp or duration for delayed delivery (e.g., "30m", "1h", "2023-12-25T10:00:00Z")
 //   - email: email address for email notifications
 //   - icon: URL to use as notification icon
+//   - markdown: enable Markdown formatting
 //   - cache: whether to cache messages (default: yes)
 //   - firebase: whether to send via Firebase (default: yes)
 //   - disabletls: set to "yes" to disable TLS verification

--- a/pkg/services/push/ntfy/ntfy.go
+++ b/pkg/services/push/ntfy/ntfy.go
@@ -116,8 +116,12 @@ func (s *Service) sendAPI(config *Config, message string) error {
 
 	// Prepare request headers
 	headers := s.client.Headers()
-	headers.Del("Content-Type")
-	headers.Set("Content-Type", "text/plain; charset=utf-8")
+	if config.Markdown {
+		headers.Set("Content-Type", "text/markdown")
+	} else {
+		headers.Set("Content-Type", "text/plain; charset=utf-8")
+	}
+
 	headers.Set("User-Agent", "shoutrrr/"+meta.Version)
 	addHeaderIfNotEmpty(&headers, "Title", config.Title)
 	addHeaderIfNotEmpty(&headers, "Priority", config.Priority.String())

--- a/pkg/services/push/ntfy/ntfy_config.go
+++ b/pkg/services/push/ntfy/ntfy_config.go
@@ -27,6 +27,7 @@ type Config struct {
 	Delay                  string   `                  desc:"Timestamp or duration for delayed delivery, see https://docs.ntfy.sh/publish/#scheduled-delivery" key:"delay,at,in"                                       optional:""`
 	Email                  string   `                  desc:"E-mail address for e-mail notifications"                                                          key:"email"                                             optional:""`
 	Icon                   string   `                  desc:"URL to use as notification icon"                                                                  key:"icon"                                              optional:""`
+	Markdown               bool     `default:"no"      desc:"Enable Markdown formatting, see https://docs.ntfy.sh/publish/#markdown-formatting"                key:"markdown"`
 	Cache                  bool     `default:"yes"     desc:"Cache messages"                                                                                   key:"cache"`
 	Firebase               bool     `default:"yes"     desc:"Send to firebase"                                                                                 key:"firebase"`
 	DisableTLSVerification bool     `default:"no"      desc:"Disable TLS certificate verification"                                                             key:"disabletlsverification"`

--- a/pkg/services/push/ntfy/ntfy_config_test.go
+++ b/pkg/services/push/ntfy/ntfy_config_test.go
@@ -1,0 +1,372 @@
+package ntfy
+
+import (
+	"strings"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	"github.com/nicholas-fedor/shoutrrr/pkg/format"
+)
+
+var _ = ginkgo.Describe("Config", func() {
+	var config *Config
+
+	ginkgo.BeforeEach(func() {
+		config = &Config{}
+	})
+
+	ginkgo.Describe("Enums", func() {
+		ginkgo.It("should return a map with Priority enum formatter", func() {
+			enums := config.Enums()
+			gomega.Expect(enums).To(gomega.HaveKey("Priority"))
+			gomega.Expect(enums["Priority"]).NotTo(gomega.BeNil())
+		})
+	})
+
+	ginkgo.Describe("GetAPIURL", func() {
+		ginkgo.It("should construct URL with https scheme by default", func() {
+			config.Scheme = "https"
+			config.Host = "ntfy.sh"
+			config.Topic = "mytopic"
+
+			result := config.GetAPIURL()
+			gomega.Expect(result).To(gomega.Equal("https://ntfy.sh/mytopic"))
+		})
+
+		ginkgo.It("should not double-slash when topic already has leading slash", func() {
+			config.Scheme = "https"
+			config.Host = "ntfy.sh"
+			config.Topic = "/mytopic"
+
+			result := config.GetAPIURL()
+			gomega.Expect(result).To(gomega.Equal("https://ntfy.sh/mytopic"))
+		})
+
+		ginkgo.It("should handle nested topic paths", func() {
+			config.Scheme = "https"
+			config.Host = "ntfy.sh"
+			config.Topic = "notifications/alerts"
+
+			result := config.GetAPIURL()
+			gomega.Expect(result).To(gomega.Equal("https://ntfy.sh/notifications/alerts"))
+		})
+
+		ginkgo.It("should use http scheme when configured", func() {
+			config.Scheme = "http"
+			config.Host = "ntfy.local"
+			config.Topic = "mytopic"
+
+			result := config.GetAPIURL()
+			gomega.Expect(result).To(gomega.Equal("http://ntfy.local/mytopic"))
+		})
+	})
+
+	ginkgo.Describe("GetURL", func() {
+		ginkgo.It("should build URL with all fields populated", func() {
+			config.Scheme = "https"
+			config.Host = "ntfy.sh"
+			config.Topic = "mytopic"
+			config.Username = "user"
+			config.Password = "pass"
+			config.Title = "Alert"
+			config.Priority = PriorityHigh
+
+			result := config.GetURL()
+			gomega.Expect(result).NotTo(gomega.BeNil())
+			gomega.Expect(result.Scheme).To(gomega.Equal(Scheme))
+			gomega.Expect(result.Host).To(gomega.Equal("ntfy.sh"))
+			gomega.Expect(result.Path).To(gomega.Equal("/mytopic"))
+			gomega.Expect(result.User.Username()).To(gomega.Equal("user"))
+			pass, hasPass := result.User.Password()
+			gomega.Expect(hasPass).To(gomega.BeTrue())
+			gomega.Expect(pass).To(gomega.Equal("pass"))
+			gomega.Expect(result.Query().Get("title")).To(gomega.Equal("Alert"))
+			gomega.Expect(result.Query().Get("priority")).To(gomega.Equal("High"))
+		})
+
+		ginkgo.It("should build URL without credentials when empty", func() {
+			config.Scheme = "https"
+			config.Host = "ntfy.sh"
+			config.Topic = "mytopic"
+
+			result := config.GetURL()
+			gomega.Expect(result).NotTo(gomega.BeNil())
+			gomega.Expect(result.User).To(gomega.BeNil())
+		})
+
+		ginkgo.It("should build URL with username only", func() {
+			config.Scheme = "https"
+			config.Host = "ntfy.sh"
+			config.Topic = "mytopic"
+			config.Username = "user"
+
+			result := config.GetURL()
+			gomega.Expect(result).NotTo(gomega.BeNil())
+			gomega.Expect(result.User.Username()).To(gomega.Equal("user"))
+			_, hasPass := result.User.Password()
+			gomega.Expect(hasPass).To(gomega.BeFalse())
+		})
+
+		ginkgo.It("should force query string even with no params", func() {
+			config.Scheme = "https"
+			config.Host = "ntfy.sh"
+			config.Topic = "mytopic"
+
+			result := config.GetURL()
+			gomega.Expect(result).NotTo(gomega.BeNil())
+			gomega.Expect(result.ForceQuery).To(gomega.BeTrue())
+		})
+	})
+
+	ginkgo.Describe("QueryFields", func() {
+		ginkgo.It("should return non-empty list of query fields", func() {
+			fields := config.QueryFields()
+			gomega.Expect(fields).NotTo(gomega.BeEmpty())
+		})
+
+		ginkgo.It("should contain priority field", func() {
+			fields := config.QueryFields()
+			gomega.Expect(fields).To(gomega.ContainElement("priority"))
+		})
+
+		ginkgo.It("should contain title field", func() {
+			fields := config.QueryFields()
+			gomega.Expect(fields).To(gomega.ContainElement("title"))
+		})
+	})
+
+	ginkgo.Describe("SetURL", func() {
+		ginkgo.It("should parse URL components correctly", func() {
+			testURL := mustParseURL("ntfy://user:pass@ntfy.example.com/mytopic?priority=5")
+
+			err := config.SetURL(testURL)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(config.Host).To(gomega.Equal("ntfy.example.com"))
+			gomega.Expect(config.Topic).To(gomega.Equal("mytopic"))
+			gomega.Expect(config.Username).To(gomega.Equal("user"))
+			gomega.Expect(config.Password).To(gomega.Equal("pass"))
+			gomega.Expect(config.Priority).To(gomega.Equal(PriorityMax))
+		})
+
+		ginkgo.It("should parse URL without credentials", func() {
+			testURL := mustParseURL("ntfy://ntfy.example.com/mytopic")
+
+			err := config.SetURL(testURL)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(config.Username).To(gomega.Equal(""))
+			gomega.Expect(config.Password).To(gomega.Equal(""))
+			gomega.Expect(config.Host).To(gomega.Equal("ntfy.example.com"))
+			gomega.Expect(config.Topic).To(gomega.Equal("mytopic"))
+		})
+
+		ginkgo.It("should parse URL with username only", func() {
+			testURL := mustParseURL("ntfy://user@ntfy.example.com/mytopic")
+
+			err := config.SetURL(testURL)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(config.Username).To(gomega.Equal("user"))
+			gomega.Expect(config.Password).To(gomega.Equal(""))
+		})
+
+		ginkgo.It("should return ErrTopicRequired for empty topic", func() {
+			testURL := mustParseURL("ntfy://ntfy.example.com/")
+
+			err := config.SetURL(testURL)
+			gomega.Expect(err).To(gomega.Equal(ErrTopicRequired))
+		})
+
+		ginkgo.It("should skip topic validation for dummy URL", func() {
+			testURL := mustParseURL("ntfy://dummy@dummy.com")
+
+			err := config.SetURL(testURL)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should parse nested topic paths", func() {
+			testURL := mustParseURL("ntfy://ntfy.example.com/level1/level2/level3")
+
+			err := config.SetURL(testURL)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(config.Topic).To(gomega.Equal("level1/level2/level3"))
+		})
+
+		ginkgo.It("should parse query parameters", func() {
+			testURL := mustParseURL("ntfy://ntfy.example.com/mytopic?title=Alert&priority=High&tags=warning,skull")
+
+			err := config.SetURL(testURL)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(config.Title).To(gomega.Equal("Alert"))
+			gomega.Expect(config.Priority).To(gomega.Equal(PriorityHigh))
+			gomega.Expect(config.Tags).To(gomega.Equal([]string{"warning", "skull"}))
+		})
+
+		ginkgo.It("should handle semicolons in query by splitting actions", func() {
+			testURL := mustParseURL("ntfy://ntfy.example.com/mytopic?actions=view;open")
+
+			err := config.SetURL(testURL)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(config.Actions).To(gomega.Equal([]string{"view", "open"}))
+		})
+
+		ginkgo.It("should parse markdown query parameter", func() {
+			testURL := mustParseURL("ntfy://ntfy.example.com/mytopic?markdown=yes")
+
+			err := config.SetURL(testURL)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(config.Markdown).To(gomega.BeTrue())
+		})
+
+		ginkgo.It("should parse cache query parameter as No", func() {
+			testURL := mustParseURL("ntfy://ntfy.example.com/mytopic?cache=no")
+
+			err := config.SetURL(testURL)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(config.Cache).To(gomega.BeFalse())
+		})
+	})
+
+	ginkgo.Describe("getURL", func() {
+		ginkgo.It("should construct URL with ntfy scheme", func() {
+			config.Scheme = "https"
+			config.Host = "ntfy.sh"
+			config.Topic = "mytopic"
+			config.Username = "user"
+			config.Password = "pass"
+
+			resolver := format.NewPropKeyResolver(config)
+			result := config.getURL(&resolver)
+			gomega.Expect(result).NotTo(gomega.BeNil())
+			gomega.Expect(result.Scheme).To(gomega.Equal(Scheme))
+			gomega.Expect(result.Host).To(gomega.Equal("ntfy.sh"))
+			gomega.Expect(result.Path).To(gomega.Equal("/mytopic"))
+			gomega.Expect(result.User.Username()).To(gomega.Equal("user"))
+			pass, hasPass := result.User.Password()
+			gomega.Expect(hasPass).To(gomega.BeTrue())
+			gomega.Expect(pass).To(gomega.Equal("pass"))
+		})
+
+		ginkgo.It("should include username without password", func() {
+			config.Scheme = "https"
+			config.Host = "ntfy.sh"
+			config.Topic = "mytopic"
+			config.Username = "user"
+
+			resolver := format.NewPropKeyResolver(config)
+			result := config.getURL(&resolver)
+			gomega.Expect(result).NotTo(gomega.BeNil())
+			gomega.Expect(result.User.Username()).To(gomega.Equal("user"))
+			_, hasPass := result.User.Password()
+			gomega.Expect(hasPass).To(gomega.BeFalse())
+		})
+	})
+
+	ginkgo.Describe("setURL", func() {
+		ginkgo.It("should set topic from URL path without leading slash", func() {
+			testURL := mustParseURL("ntfy://ntfy.example.com/mytopic")
+
+			resolver := format.NewPropKeyResolver(config)
+			err := config.setURL(&resolver, testURL)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(config.Topic).To(gomega.Equal("mytopic"))
+		})
+
+		ginkgo.It("should set topic from URL path with leading slash", func() {
+			testURL := mustParseURL("ntfy://ntfy.example.com//mytopic")
+
+			resolver := format.NewPropKeyResolver(config)
+			err := config.setURL(&resolver, testURL)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(config.Topic).To(gomega.Equal("/mytopic"))
+		})
+
+		ginkgo.It("should clear credentials when URL has no user info", func() {
+			testURL := mustParseURL("ntfy://ntfy.example.com/mytopic")
+
+			config.Username = "olduser"
+			config.Password = "oldpass"
+
+			resolver := format.NewPropKeyResolver(config)
+			err := config.setURL(&resolver, testURL)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(config.Username).To(gomega.Equal(""))
+			gomega.Expect(config.Password).To(gomega.Equal(""))
+		})
+
+		ginkgo.It("should set host from URL", func() {
+			testURL := mustParseURL("ntfy://ntfy.example.com:8080/mytopic")
+
+			resolver := format.NewPropKeyResolver(config)
+			err := config.setURL(&resolver, testURL)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(config.Host).To(gomega.Equal("ntfy.example.com:8080"))
+		})
+
+		ginkgo.It("should split semicolons in actions query", func() {
+			testURL := mustParseURL("ntfy://ntfy.example.com/mytopic?actions=a;b;c")
+			gomega.Expect(strings.Contains(testURL.RawQuery, ";")).To(gomega.BeTrue())
+
+			resolver := format.NewPropKeyResolver(config)
+			err := config.setURL(&resolver, testURL)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(config.Actions).To(gomega.Equal([]string{"a", "b", "c"}))
+		})
+
+		ginkgo.It("should return ErrTopicRequired for empty topic except dummy URL", func() {
+			testURL := mustParseURL("ntfy://ntfy.example.com/")
+
+			resolver := format.NewPropKeyResolver(config)
+			err := config.setURL(&resolver, testURL)
+			gomega.Expect(err).To(gomega.Equal(ErrTopicRequired))
+		})
+
+		ginkgo.It("should skip topic validation for dummy URL", func() {
+			testURL := mustParseURL("ntfy://dummy@dummy.com")
+
+			resolver := format.NewPropKeyResolver(config)
+			err := config.setURL(&resolver, testURL)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+	})
+
+	ginkgo.Describe("default values", func() {
+		ginkgo.It("should apply defaults from struct tags when only required fields are set", func() {
+			svc := &Service{}
+			serviceURL := mustParseURL("ntfy://hostname/topic")
+			gomega.Expect(svc.Initialize(serviceURL, &noOpLogger{})).To(gomega.Succeed())
+			gomega.Expect(svc.Config.Host).To(gomega.Equal("hostname"))
+			gomega.Expect(svc.Config.Topic).To(gomega.Equal("topic"))
+			gomega.Expect(svc.Config.Scheme).To(gomega.Equal("https"))
+			gomega.Expect(svc.Config.Tags).To(gomega.Equal([]string{""}))
+			gomega.Expect(svc.Config.Actions).To(gomega.Equal([]string{""}))
+			gomega.Expect(svc.Config.Priority).To(gomega.Equal(PriorityDefault))
+			gomega.Expect(svc.Config.Markdown).To(gomega.BeFalse())
+			gomega.Expect(svc.Config.Firebase).To(gomega.BeTrue())
+			gomega.Expect(svc.Config.Cache).To(gomega.BeTrue())
+			gomega.Expect(svc.Config.DisableTLSVerification).To(gomega.BeFalse())
+			gomega.Expect(svc.Config.DisableTLS).To(gomega.BeFalse())
+		})
+	})
+
+	ginkgo.Describe("URL round-trip", func() {
+		ginkgo.It("should be identical after de-/serialization", func() {
+			testURL := "ntfy://user:pass@example.com:2225/topic?cache=No&click=CLICK&disabletls=No&disabletlsverification=No&firebase=No&icon=ICON&markdown=No&priority=Max&scheme=http&title=TITLE"
+			cfg := &Config{}
+			pkr := format.NewPropKeyResolver(cfg)
+			gomega.Expect(cfg.setURL(&pkr, mustParseURL(testURL))).To(gomega.Succeed())
+			gomega.Expect(cfg.GetURL().String()).To(gomega.Equal(testURL))
+		})
+	})
+
+	ginkgo.Describe("Service API compliance", func() {
+		ginkgo.It("should pass standard config tests", func() {
+			cfg := &Config{}
+			enums := cfg.Enums()
+			gomega.Expect(enums).To(gomega.HaveKey("Priority"))
+
+			resolver := format.NewPropKeyResolver(cfg)
+			fields := resolver.QueryFields()
+			gomega.Expect(fields).To(gomega.HaveLen(18))
+		})
+	})
+})

--- a/pkg/services/push/ntfy/ntfy_json_test.go
+++ b/pkg/services/push/ntfy/ntfy_json_test.go
@@ -1,0 +1,54 @@
+package ntfy
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("apiResponseError", func() {
+	ginkgo.Describe("Error", func() {
+		ginkgo.It("should format message and code", func() {
+			e := &apiResponseError{
+				Code:    404,
+				Message: "not found",
+			}
+			gomega.Expect(e.Error()).To(gomega.Equal("server response: not found (404)"))
+		})
+
+		ginkgo.It("should include link when present", func() {
+			e := &apiResponseError{
+				Code:    400,
+				Message: "bad request",
+				Link:    "https://docs.ntfy.sh",
+			}
+			gomega.Expect(e.Error()).To(gomega.Equal(
+				"server response: bad request (400), see: https://docs.ntfy.sh",
+			))
+		})
+
+		ginkgo.It("should not include link when empty", func() {
+			e := &apiResponseError{
+				Code:    500,
+				Message: "server error",
+				Link:    "",
+			}
+			gomega.Expect(e.Error()).To(gomega.Equal("server response: server error (500)"))
+		})
+
+		ginkgo.It("should handle zero code", func() {
+			e := &apiResponseError{
+				Code:    0,
+				Message: "unknown error",
+			}
+			gomega.Expect(e.Error()).To(gomega.Equal("server response: unknown error (0)"))
+		})
+
+		ginkgo.It("should handle empty message", func() {
+			e := &apiResponseError{
+				Code:    500,
+				Message: "",
+			}
+			gomega.Expect(e.Error()).To(gomega.Equal("server response:  (500)"))
+		})
+	})
+})

--- a/pkg/services/push/ntfy/ntfy_priority_test.go
+++ b/pkg/services/push/ntfy/ntfy_priority_test.go
@@ -1,0 +1,56 @@
+package ntfy
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("Priority", func() {
+	ginkgo.Describe("String", func() {
+		ginkgo.It("should return 'Min' for PriorityMin", func() {
+			gomega.Expect(PriorityMin.String()).To(gomega.Equal("Min"))
+		})
+
+		ginkgo.It("should return 'Low' for PriorityLow", func() {
+			gomega.Expect(PriorityLow.String()).To(gomega.Equal("Low"))
+		})
+
+		ginkgo.It("should return 'Default' for PriorityDefault", func() {
+			gomega.Expect(PriorityDefault.String()).To(gomega.Equal("Default"))
+		})
+
+		ginkgo.It("should return 'High' for PriorityHigh", func() {
+			gomega.Expect(PriorityHigh.String()).To(gomega.Equal("High"))
+		})
+
+		ginkgo.It("should return 'Max' for PriorityMax", func() {
+			gomega.Expect(PriorityMax.String()).To(gomega.Equal("Max"))
+		})
+
+		ginkgo.It("should return formatted string for unknown values", func() {
+			unknown := priority(99)
+			result := unknown.String()
+			gomega.Expect(result).NotTo(gomega.BeEmpty())
+		})
+	})
+
+	ginkgo.Describe("Priority values", func() {
+		ginkgo.It("should have correct numeric values", func() {
+			gomega.Expect(int(PriorityMin)).To(gomega.Equal(1))
+			gomega.Expect(int(PriorityLow)).To(gomega.Equal(2))
+			gomega.Expect(int(PriorityDefault)).To(gomega.Equal(3))
+			gomega.Expect(int(PriorityHigh)).To(gomega.Equal(4))
+			gomega.Expect(int(PriorityMax)).To(gomega.Equal(5))
+		})
+	})
+
+	ginkgo.Describe("Priority enum formatter", func() {
+		ginkgo.It("should have non-nil Enum formatter", func() {
+			gomega.Expect(Priority.Enum).NotTo(gomega.BeNil())
+		})
+
+		ginkgo.It("should map string names to values", func() {
+			gomega.Expect(Priority.Enum.Parse("High")).To(gomega.Equal(int(PriorityHigh)))
+		})
+	})
+})

--- a/pkg/services/push/ntfy/ntfy_suite_test.go
+++ b/pkg/services/push/ntfy/ntfy_suite_test.go
@@ -1,0 +1,37 @@
+package ntfy
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	"github.com/nicholas-fedor/shoutrrr/pkg/types"
+	jsonclientmocks "github.com/nicholas-fedor/shoutrrr/pkg/util/jsonclient/mocks"
+)
+
+type noOpLogger struct{}
+
+var _ types.StdLogger = (*noOpLogger)(nil)
+
+func (n *noOpLogger) Print(_ ...any)            {}
+func (n *noOpLogger) Printf(_ string, _ ...any) {}
+func (n *noOpLogger) Println(_ ...any)          {}
+
+func TestNtfy(t *testing.T) {
+	t.Parallel()
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "Ntfy Suite")
+}
+
+func newMockJSONClient() *jsonclientmocks.MockClient {
+	return jsonclientmocks.NewMockClient(ginkgo.GinkgoT())
+}
+
+func mustParseURL(raw string) *url.URL {
+	parsed, err := url.Parse(raw)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	return parsed
+}

--- a/pkg/services/push/ntfy/ntfy_suite_test.go
+++ b/pkg/services/push/ntfy/ntfy_suite_test.go
@@ -19,8 +19,7 @@ func (n *noOpLogger) Print(_ ...any)            {}
 func (n *noOpLogger) Printf(_ string, _ ...any) {}
 func (n *noOpLogger) Println(_ ...any)          {}
 
-func TestNtfy(t *testing.T) {
-	t.Parallel()
+func TestNtfy(t *testing.T) { //nolint:paralleltest // Ginkgo manages its own parallelization
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	ginkgo.RunSpecs(t, "Ntfy Suite")
 }

--- a/pkg/services/push/ntfy/ntfy_test.go
+++ b/pkg/services/push/ntfy/ntfy_test.go
@@ -274,7 +274,7 @@ var _ = ginkgo.Describe("Service", func() {
 			gomega.Expect(headers.Get("Authorization")).To(gomega.HavePrefix("Basic "))
 		})
 
-		ginkgo.It("should skip Cache header when Cache is disabled", func() {
+		ginkgo.It("should set Cache header to no when Cache is disabled", func() {
 			service.Config.Cache = false
 
 			mockJSON.On("Post", mock.Anything, mock.Anything, mock.Anything).
@@ -285,7 +285,7 @@ var _ = ginkgo.Describe("Service", func() {
 			gomega.Expect(headers.Get("Cache")).To(gomega.Equal("no"))
 		})
 
-		ginkgo.It("should skip Firebase header when Firebase is disabled", func() {
+		ginkgo.It("should set Firebase header to no when Firebase is disabled", func() {
 			service.Config.Firebase = false
 
 			mockJSON.On("Post", mock.Anything, mock.Anything, mock.Anything).

--- a/pkg/services/push/ntfy/ntfy_test.go
+++ b/pkg/services/push/ntfy/ntfy_test.go
@@ -1,1518 +1,581 @@
 package ntfy
 
 import (
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/tls"
-	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/json"
-	"fmt"
-	"log"
-	"math/big"
-	"net"
+	"io"
 	"net/http"
-	"net/http/httptest"
-	"net/url"
-	"os"
-	"testing"
-	"time"
 
-	"github.com/jarcoal/httpmock"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
-	gomegaformat "github.com/onsi/gomega/format"
+	mock "github.com/stretchr/testify/mock"
 
 	"github.com/nicholas-fedor/shoutrrr/internal/testutils"
-	"github.com/nicholas-fedor/shoutrrr/pkg/format"
+	"github.com/nicholas-fedor/shoutrrr/pkg/types"
 	"github.com/nicholas-fedor/shoutrrr/pkg/util/jsonclient"
+	jsonclientmocks "github.com/nicholas-fedor/shoutrrr/pkg/util/jsonclient/mocks"
 )
 
-var (
-	service    = &Service{}
-	envBarkURL *url.URL
-	logger     *log.Logger = testutils.TestLogger()
-	_                      = ginkgo.BeforeSuite(func() {
-		envBarkURL, _ = url.Parse(os.Getenv("SHOUTRRR_NTFY_URL"))
-	})
-)
+var _ = ginkgo.Describe("Service", func() {
+	var (
+		service  *Service
+		mockJSON *jsonclientmocks.MockClient
+		logger   types.StdLogger
+	)
 
-var _ = ginkgo.Describe("the ntfy service", func() {
-	ginkgo.When("running integration tests", func() {
-		ginkgo.It("should not error out", func() {
-			if envBarkURL.String() == "" {
-				ginkgo.Skip("No integration test ENV URL was set")
-
-				return
-			}
-
-			serviceURL := testutils.URLMust(envBarkURL.String())
-			gomega.Expect(service.Initialize(serviceURL, logger)).To(gomega.Succeed())
-			gomega.Expect(service.Send("This is an integration test message", nil)).
-				To(gomega.Succeed())
-		})
+	ginkgo.BeforeEach(func() {
+		mockJSON = newMockJSONClient()
+		logger = &noOpLogger{}
+		service = &Service{
+			Config: &Config{
+				Scheme: "https",
+				Host:   "ntfy.sh",
+				Topic:  "mytopic",
+			},
+		}
+		service.SetLogger(logger)
+		service.client = mockJSON
 	})
 
-	ginkgo.Describe("the config", func() {
-		ginkgo.When("getting a API URL", func() {
-			ginkgo.It("should return the expected URL", func() {
-				gomega.Expect((&Config{
-					Host:   "host:8080",
-					Scheme: "http",
-					Topic:  "topic",
-				}).GetAPIURL()).To(gomega.Equal("http://host:8080/topic"))
-			})
-		})
-		ginkgo.When("only required fields are set", func() {
-			ginkgo.It("should set the optional fields to the defaults", func() {
-				serviceURL := testutils.URLMust("ntfy://hostname/topic")
-				gomega.Expect(service.Initialize(serviceURL, logger)).To(gomega.Succeed())
-				gomega.Expect(*service.Config).To(gomega.Equal(Config{
-					Host:                   "hostname",
-					Topic:                  "topic",
-					Scheme:                 "https",
-					Tags:                   []string{""},
-					Actions:                []string{""},
-					Priority:               3,
-					Firebase:               true,
-					Cache:                  true,
-					DisableTLSVerification: false,
-					DisableTLS:             false,
-				}))
-			})
-		})
-		ginkgo.When("parsing the configuration URL", func() {
-			ginkgo.It("should be identical after de-/serialization", func() {
-				testURL := "ntfy://user:pass@example.com:2225/topic?cache=No&click=CLICK&disabletls=No&disabletlsverification=No&firebase=No&icon=ICON&priority=Max&scheme=http&title=TITLE"
-				config := &Config{}
-				service.client = jsonclient.NewWithHTTPClient(service.httpClient)
-				pkr := format.NewPropKeyResolver(config)
-				gomega.Expect(config.setURL(&pkr, testutils.URLMust(testURL))).
-					To(gomega.Succeed(), "verifying")
-				gomega.Expect(config.GetURL().String()).To(gomega.Equal(testURL))
-			})
+	ginkgo.Describe("GetID", func() {
+		ginkgo.It("should return the scheme name", func() {
+			gomega.Expect(service.GetID()).To(gomega.Equal(Scheme))
 		})
 	})
 
-	ginkgo.When("sending the push payload", func() {
+	ginkgo.Describe("Initialize", func() {
+		ginkgo.It("should parse a valid URL and initialize config", func() {
+			serviceURL := mustParseURL("ntfy://user:pass@ntfy.example.com/mytopic?priority=5")
+
+			err := service.Initialize(serviceURL, logger)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(service.Config).NotTo(gomega.BeNil())
+			gomega.Expect(service.Config.Host).To(gomega.Equal("ntfy.example.com"))
+			gomega.Expect(service.Config.Topic).To(gomega.Equal("mytopic"))
+			gomega.Expect(service.Config.Username).To(gomega.Equal("user"))
+			gomega.Expect(service.Config.Password).To(gomega.Equal("pass"))
+			gomega.Expect(service.Config.Priority).To(gomega.Equal(PriorityMax))
+		})
+
+		ginkgo.It("should return an error when topic is missing", func() {
+			serviceURL := mustParseURL("ntfy://ntfy.example.com/")
+
+			err := service.Initialize(serviceURL, logger)
+			gomega.Expect(err).To(gomega.Equal(ErrTopicRequired))
+		})
+
+		ginkgo.It("should skip topic validation for dummy URL", func() {
+			serviceURL := mustParseURL("ntfy://dummy@dummy.com")
+
+			err := service.Initialize(serviceURL, logger)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should force HTTP scheme when DisableTLS is set", func() {
+			serviceURL := mustParseURL("ntfy://ntfy.example.com/mytopic?disabletls=yes")
+
+			err := service.Initialize(serviceURL, logger)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(service.Config.Scheme).To(gomega.Equal("http"))
+		})
+
+		ginkgo.It("should create HTTP client with TLS 1.2 minimum when TLS is enabled", func() {
+			serviceURL := mustParseURL("ntfy://ntfy.example.com/mytopic")
+
+			err := service.Initialize(serviceURL, logger)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(service.httpClient).NotTo(gomega.BeNil())
+		})
+
+		ginkgo.It("should create HTTP client with InsecureSkipVerify when DisableTLSVerification is set", func() {
+			serviceURL := mustParseURL("ntfy://ntfy.example.com/mytopic?disabletlsverification=yes")
+
+			err := service.Initialize(serviceURL, logger)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(service.httpClient).NotTo(gomega.BeNil())
+		})
+
+		ginkgo.It("should use existing HTTP client when already set", func() {
+			existingClient := &http.Client{}
+			service.httpClient = existingClient
+			serviceURL := mustParseURL("ntfy://ntfy.example.com/mytopic")
+
+			err := service.Initialize(serviceURL, logger)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(service.httpClient).To(gomega.BeIdenticalTo(existingClient))
+		})
+
+		ginkgo.It("should create jsonclient from HTTP client", func() {
+			serviceURL := mustParseURL("ntfy://ntfy.example.com/mytopic")
+
+			err := service.Initialize(serviceURL, logger)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(service.client).NotTo(gomega.BeNil())
+		})
+	})
+
+	ginkgo.Describe("Send", func() {
 		ginkgo.BeforeEach(func() {
-			serviceURL := testutils.URLMust("ntfy://:devicekey@hostname/testtopic")
-			gomega.Expect(service.Initialize(serviceURL, logger)).To(gomega.Succeed())
-			httpmock.ActivateNonDefault(service.httpClient.(*http.Client))
-		})
-		ginkgo.AfterEach(func() {
-			httpmock.DeactivateAndReset()
+			mockJSON.On("Headers").Return(http.Header{})
 		})
 
-		ginkgo.It("should not report an error if the server accepts the payload", func() {
-			httpmock.RegisterResponder(
-				"POST",
-				service.Config.GetAPIURL(),
-				testutils.JSONRespondMust(200, apiResponseError{
-					Code:    http.StatusOK,
-					Message: "OK",
-				}),
-			)
-			gomega.Expect(service.Send("Message", nil)).To(gomega.Succeed())
+		ginkgo.It("should send message via sendAPI", func() {
+			serviceURL := mustParseURL("ntfy://ntfy.example.com/mytopic")
+			gomega.Expect(service.Initialize(serviceURL, logger)).NotTo(gomega.HaveOccurred())
+			service.client = mockJSON
+
+			mockJSON.On("Post", mock.Anything, mock.Anything, mock.Anything).
+				Return(nil)
+
+			err := service.Send("hello", nil)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 
-		ginkgo.It("should not panic if a server error occurs", func() {
-			httpmock.RegisterResponder(
-				"POST",
-				service.Config.GetAPIURL(),
-				testutils.JSONRespondMust(500, apiResponseError{
-					Code:    500,
-					Message: "someone turned off the internet",
-				}),
-			)
-			gomega.Expect(service.Send("Message", nil)).To(gomega.HaveOccurred())
+		ginkgo.It("should update config from params before sending", func() {
+			serviceURL := mustParseURL("ntfy://ntfy.example.com/mytopic")
+			gomega.Expect(service.Initialize(serviceURL, logger)).NotTo(gomega.HaveOccurred())
+			service.client = mockJSON
+
+			mockJSON.On("Post", mock.Anything, mock.Anything, mock.Anything).
+				Return(nil)
+
+			params := &types.Params{"title": "New Title"}
+			err := service.Send("hello", params)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(service.Config.Title).To(gomega.Equal("New Title"))
 		})
 
-		ginkgo.It("should not panic if a communication error occurs", func() {
-			httpmock.DeactivateAndReset()
+		ginkgo.It("should return error when sendAPI fails", func() {
+			serviceURL := mustParseURL("ntfy://ntfy.example.com/mytopic")
+			gomega.Expect(service.Initialize(serviceURL, logger)).NotTo(gomega.HaveOccurred())
+			service.client = mockJSON
 
-			serviceURL := testutils.URLMust("ntfy://:devicekey@nonresolvablehostname/testtopic")
-			gomega.Expect(service.Initialize(serviceURL, logger)).To(gomega.Succeed())
-			gomega.Expect(service.Send("Message", nil)).To(gomega.HaveOccurred())
-		})
-	})
+			mockJSON.On("Post", mock.Anything, mock.Anything, mock.Anything).
+				Return(io.ErrClosedPipe)
+			mockJSON.EXPECT().ErrorResponse(mock.Anything, mock.Anything).
+				Return(false)
 
-	ginkgo.Describe("the basic service API", func() {
-		ginkgo.Describe("the service config", func() {
-			ginkgo.It("should implement basic service config API methods correctly", func() {
-				testutils.TestConfigGetInvalidQueryValue(&Config{})
-				testutils.TestConfigSetInvalidQueryValue(&Config{}, "ntfy://host/topic?foo=bar")
-				testutils.TestConfigSetDefaultValues(&Config{})
-				testutils.TestConfigGetEnumsCount(&Config{}, 1)
-				testutils.TestConfigGetFieldsCount(&Config{}, 17)
-			})
-		})
-		ginkgo.Describe("the service instance", func() {
-			ginkgo.BeforeEach(func() {
-				serviceURL := testutils.URLMust("ntfy://:devicekey@hostname/testtopic")
-				gomega.Expect(service.Initialize(serviceURL, logger)).To(gomega.Succeed())
-				httpmock.ActivateNonDefault(service.httpClient.(*http.Client))
-			})
-			ginkgo.AfterEach(func() {
-				httpmock.DeactivateAndReset()
-			})
-			ginkgo.It("should implement basic service API methods correctly", func() {
-				serviceURL := testutils.URLMust("ntfy://:devicekey@hostname/testtopic")
-				gomega.Expect(service.Initialize(serviceURL, logger)).To(gomega.Succeed())
-				testutils.TestServiceSetInvalidParamValue(service, "foo", "bar")
-			})
-		})
-	})
-
-	ginkgo.Describe("TLS certificate verification", func() {
-		ginkgo.It(
-			"should fail with TLS certificate verification error when RootCAs is empty",
-			func() {
-				// Generate a self-signed certificate that is not trusted by Go's default RootCAs
-				privKey, err := rsa.GenerateKey(rand.Reader, 2048)
-				gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-				template := x509.Certificate{
-					SerialNumber: big.NewInt(1),
-					Subject: pkix.Name{
-						Organization: []string{"Test Organization"},
-					},
-					NotBefore:             time.Now(),
-					NotAfter:              time.Now().Add(time.Hour),
-					KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-					ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-					BasicConstraintsValid: true,
-					IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
-				}
-
-				derBytes, err := x509.CreateCertificate(
-					rand.Reader,
-					&template,
-					&template,
-					&privKey.PublicKey,
-					privKey,
-				)
-				gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-				// Create a test server with the self-signed certificate
-				server := httptest.NewUnstartedServer(
-					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-						w.WriteHeader(http.StatusOK)
-						_, _ = w.Write([]byte("OK"))
-					}),
-				)
-				server.TLS = &tls.Config{
-					Certificates: []tls.Certificate{
-						{
-							Certificate: [][]byte{derBytes},
-							PrivateKey:  privKey,
-						},
-					},
-				}
-
-				server.StartTLS()
-				defer server.Close()
-
-				// Create an HTTP client with empty RootCAs to simulate the problematic configuration
-				client := &http.Client{
-					Transport: &http.Transport{
-						TLSClientConfig: &tls.Config{
-							RootCAs: x509.NewCertPool(), // Empty cert pool
-						},
-					},
-				}
-
-				// Attempt to make a request to the test server
-				resp, err := client.Get(server.URL)
-
-				// Assert that the request fails with the exact error message
-				gomega.Expect(err).To(gomega.HaveOccurred())
-				gomega.Expect(err.Error()).
-					To(gomega.ContainSubstring("tls: failed to verify certificate: x509: certificate signed by unknown authority"))
-
-				// Ensure response is nil since the request failed
-				gomega.Expect(resp).To(gomega.BeNil())
-			},
-		)
-
-		ginkgo.It("should succeed when RootCAs is properly configured", func() {
-			// Create a test server with a valid TLS certificate
-			server := httptest.NewTLSServer(
-				http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write([]byte("OK"))
-				}),
-			)
-			defer server.Close()
-
-			// Create a dedicated HTTP client with the test server's certificate in RootCAs
-			certPool := x509.NewCertPool()
-			certPool.AddCert(server.Certificate())
-
-			transport := &http.Transport{
-				TLSClientConfig: &tls.Config{
-					RootCAs: certPool,
-				},
-			}
-			client := &http.Client{Transport: transport}
-
-			// Attempt to make a request to the test server
-			resp, err := client.Get(server.URL)
-
-			// Assert that the request succeeds
-			gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-			gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
-
-			_ = resp.Body.Close()
-		})
-
-		ginkgo.It(
-			"should fail when using the actual ntfy service with an untrusted certificate",
-			func() {
-				// Generate a self-signed certificate that is not trusted by Go's default RootCAs
-				privKey, err := rsa.GenerateKey(rand.Reader, 2048)
-				gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-				template := x509.Certificate{
-					SerialNumber: big.NewInt(1),
-					Subject: pkix.Name{
-						Organization: []string{"Test Organization"},
-					},
-					NotBefore:             time.Now(),
-					NotAfter:              time.Now().Add(time.Hour),
-					KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-					ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-					BasicConstraintsValid: true,
-					IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
-				}
-
-				derBytes, err := x509.CreateCertificate(
-					rand.Reader,
-					&template,
-					&template,
-					&privKey.PublicKey,
-					privKey,
-				)
-				gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-				// Create a test server with the self-signed certificate
-				server := httptest.NewUnstartedServer(
-					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-						// Simulate successful ntfy API response
-						response := apiResponseError{
-							Code:    http.StatusOK,
-							Message: "OK",
-						}
-
-						w.Header().Set("Content-Type", "application/json")
-						w.WriteHeader(http.StatusOK)
-						_ = json.NewEncoder(w).Encode(response)
-					}),
-				)
-				server.TLS = &tls.Config{
-					Certificates: []tls.Certificate{
-						{
-							Certificate: [][]byte{derBytes},
-							PrivateKey:  privKey,
-						},
-					},
-				}
-
-				server.StartTLS()
-				defer server.Close()
-
-				// Parse the test server URL to extract host and construct ntfy URL
-				serverURL, err := url.Parse(server.URL)
-				gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-				// Create ntfy service URL pointing to the test server
-				serviceURL := testutils.URLMust(fmt.Sprintf("ntfy://%s/testtopic", serverURL.Host))
-
-				// Initialize the ntfy service with the test server URL
-				gomega.Expect(service.Initialize(serviceURL, logger)).To(gomega.Succeed())
-
-				// Attempt to send a message using the actual service.Send method
-				// This should fail due to untrusted certificate
-				gomega.Expect(service.Send("Test message", nil)).To(gomega.HaveOccurred())
-			},
-		)
-		ginkgo.It(
-			"should fail with Let's Encrypt certificate when RootCAs is empty (GitHub Issue #410 scenario)",
-			func() {
-				// This test simulates the exact scenario from GitHub Issue #410:
-				// Attempting to send to an ntfy server with a valid Let's Encrypt certificate
-				// but failing due to TLS verification issues caused by empty RootCAs
-
-				// Generate a certificate that mimics Let's Encrypt structure (self-signed for testing)
-				privKey, err := rsa.GenerateKey(rand.Reader, 2048)
-				gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-				// Create a certificate with Let's Encrypt-like subject
-				template := x509.Certificate{
-					SerialNumber: big.NewInt(1),
-					Subject: pkix.Name{
-						CommonName:   "ntfy.sh",
-						Organization: []string{"Let's Encrypt"},
-					},
-					NotBefore:             time.Now(),
-					NotAfter:              time.Now().Add(time.Hour),
-					KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-					ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-					BasicConstraintsValid: true,
-					DNSNames:              []string{"ntfy.sh"},
-				}
-
-				derBytes, err := x509.CreateCertificate(
-					rand.Reader,
-					&template,
-					&template,
-					&privKey.PublicKey,
-					privKey,
-				)
-				gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-				// Create a test server simulating ntfy.sh with Let's Encrypt-like certificate
-				server := httptest.NewUnstartedServer(
-					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-						// Simulate successful ntfy API response
-						response := apiResponseError{
-							Code:    http.StatusOK,
-							Message: "OK",
-						}
-
-						w.Header().Set("Content-Type", "application/json")
-						w.WriteHeader(http.StatusOK)
-						_ = json.NewEncoder(w).Encode(response)
-					}),
-				)
-				server.TLS = &tls.Config{
-					Certificates: []tls.Certificate{
-						{
-							Certificate: [][]byte{derBytes},
-							PrivateKey:  privKey,
-						},
-					},
-				}
-
-				server.StartTLS()
-				defer server.Close()
-
-				// Parse the test server URL to extract host and construct ntfy URL
-				serverURL, err := url.Parse(server.URL)
-				gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-				// Create ntfy service URL pointing to the test server
-				serviceURL := testutils.URLMust(fmt.Sprintf("ntfy://%s/testtopic", serverURL.Host))
-
-				// Initialize the ntfy service with the test server URL
-				gomega.Expect(service.Initialize(serviceURL, logger)).To(gomega.Succeed())
-
-				// Attempt to send a message - this should fail because the certificate
-				// is not in the default RootCAs (simulating the issue where RootCAs is empty)
-				err = service.Send("Test message", nil)
-				gomega.Expect(err).To(gomega.HaveOccurred())
-				gomega.Expect(err.Error()).
-					To(gomega.ContainSubstring("tls: failed to verify certificate"))
-			},
-		)
-
-		ginkgo.It("should fail with outdated RootCAs that don't include Let's Encrypt", func() {
-			// This test demonstrates failure when using RootCAs that predate Let's Encrypt
-			// (before 2016 when Let's Encrypt became widely available)
-
-			// Generate a certificate signed by a CA that represents an outdated RootCAs
-			privKey, err := rsa.GenerateKey(rand.Reader, 2048)
-			gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-			// Create a CA certificate (representing an old CA that doesn't know about Let's Encrypt)
-			caTemplate := x509.Certificate{
-				SerialNumber: big.NewInt(1),
-				Subject: pkix.Name{
-					CommonName:   "Old CA",
-					Organization: []string{"Pre-2016 Certificate Authority"},
-				},
-				NotBefore:             time.Now().AddDate(-10, 0, 0), // 10 years ago
-				NotAfter:              time.Now().AddDate(10, 0, 0),
-				KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
-				BasicConstraintsValid: true,
-				IsCA:                  true,
-			}
-
-			caPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
-			gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-			caDerBytes, err := x509.CreateCertificate(
-				rand.Reader,
-				&caTemplate,
-				&caTemplate,
-				&caPrivKey.PublicKey,
-				caPrivKey,
-			)
-			gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-			// Generate a second CA (modern/Let's Encrypt-like)
-			caTemplateModern := x509.Certificate{
-				SerialNumber: big.NewInt(3),
-				Subject: pkix.Name{
-					CommonName:   "Let's Encrypt Authority X3",
-					Organization: []string{"Let's Encrypt"},
-				},
-				NotBefore:             time.Now().AddDate(-2, 0, 0), // 2 years ago
-				NotAfter:              time.Now().AddDate(5, 0, 0),
-				KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
-				BasicConstraintsValid: true,
-				IsCA:                  true,
-			}
-
-			caPrivKeyModern, err := rsa.GenerateKey(rand.Reader, 2048)
-			gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-			modernCaDerBytes, err := x509.CreateCertificate(
-				rand.Reader,
-				&caTemplateModern,
-				&caTemplateModern,
-				&caPrivKeyModern.PublicKey,
-				caPrivKeyModern,
-			)
-			gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-			// Create server certificate signed by the modern CA
-			serverTemplate := x509.Certificate{
-				SerialNumber: big.NewInt(2),
-				Subject: pkix.Name{
-					CommonName:   "ntfy.sh",
-					Organization: []string{"Let's Encrypt"},
-				},
-				NotBefore:             time.Now(),
-				NotAfter:              time.Now().Add(time.Hour),
-				KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-				ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-				BasicConstraintsValid: true,
-				DNSNames:              []string{"ntfy.sh"},
-			}
-
-			serverDerBytes, err := x509.CreateCertificate(
-				rand.Reader,
-				&serverTemplate,
-				&caTemplateModern,
-				&privKey.PublicKey,
-				caPrivKeyModern,
-			)
-			gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-			// Create a test server with the certificate signed by modern CA
-			server := httptest.NewUnstartedServer(
-				http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-					response := apiResponseError{
-						Code:    http.StatusOK,
-						Message: "OK",
-					}
-
-					w.Header().Set("Content-Type", "application/json")
-					w.WriteHeader(http.StatusOK)
-					_ = json.NewEncoder(w).Encode(response)
-				}),
-			)
-			server.TLS = &tls.Config{
-				Certificates: []tls.Certificate{
-					{
-						Certificate: [][]byte{serverDerBytes, modernCaDerBytes},
-						PrivateKey:  privKey,
-					},
-				},
-				MinVersion: tls.VersionTLS13,
-			}
-
-			server.StartTLS()
-			defer server.Close()
-
-			// Create RootCAs that only contains the old CA (simulating outdated trust store)
-			outdatedRootCAs := x509.NewCertPool()
-			caCert, err := x509.ParseCertificate(caDerBytes)
-			gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-			outdatedRootCAs.AddCert(caCert)
-
-			// Create a dedicated HTTP client with outdated RootCAs
-			transport := &http.Transport{
-				TLSClientConfig: &tls.Config{
-					RootCAs: outdatedRootCAs,
-				},
-			}
-			client := &http.Client{Transport: transport}
-			service.SetHTTPClient(client)
-
-			// Parse the test server URL to extract host and construct ntfy URL
-			serverURL, err := url.Parse(server.URL)
-			gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-			// Create ntfy service URL pointing to the test server
-			serviceURL := testutils.URLMust(fmt.Sprintf("ntfy://%s/testtopic", serverURL.Host))
-
-			// Initialize the ntfy service with the test server URL
-			gomega.Expect(service.Initialize(serviceURL, logger)).To(gomega.Succeed())
-
-			// Attempt to send a message - this should fail because the certificate
-			// is signed by a CA not in the outdated RootCAs
-			err = service.Send("Test message", nil)
+			err := service.Send("hello", nil)
 			gomega.Expect(err).To(gomega.HaveOccurred())
-			gomega.Expect(err.Error()).
-				To(gomega.ContainSubstring("tls: failed to verify certificate"))
-		})
-
-		ginkgo.It("should fail with missing intermediate certificates", func() {
-			// This test demonstrates failure when intermediate certificates are missing
-			// from the certificate chain, which is common with Let's Encrypt certificates
-			privKey, err := rsa.GenerateKey(rand.Reader, 2048)
-			gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-			// Create an intermediate CA certificate
-			intermediateTemplate := x509.Certificate{
-				SerialNumber: big.NewInt(1),
-				Subject: pkix.Name{
-					CommonName:   "R3",
-					Organization: []string{"Let's Encrypt"},
-				},
-				NotBefore:             time.Now().AddDate(-1, 0, 0),
-				NotAfter:              time.Now().AddDate(1, 0, 0),
-				KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
-				BasicConstraintsValid: true,
-				IsCA:                  true,
-			}
-
-			intermediatePrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
-			gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-			// Create root CA certificate
-			rootTemplate := x509.Certificate{
-				SerialNumber: big.NewInt(0),
-				Subject: pkix.Name{
-					CommonName:   "ISRG Root X1",
-					Organization: []string{"Internet Security Research Group"},
-				},
-				NotBefore:             time.Now().AddDate(-2, 0, 0),
-				NotAfter:              time.Now().AddDate(10, 0, 0),
-				KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
-				BasicConstraintsValid: true,
-				IsCA:                  true,
-			}
-
-			rootPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
-			gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-			rootDerBytes, err := x509.CreateCertificate(
-				rand.Reader,
-				&rootTemplate,
-				&rootTemplate,
-				&rootPrivKey.PublicKey,
-				rootPrivKey,
-			)
-			gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-			intermediateDerBytes, err := x509.CreateCertificate(
-				rand.Reader,
-				&intermediateTemplate,
-				&rootTemplate,
-				&intermediatePrivKey.PublicKey,
-				rootPrivKey,
-			)
-			gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-			// Create server certificate signed by intermediate CA
-			serverTemplate := x509.Certificate{
-				SerialNumber: big.NewInt(2),
-				Subject: pkix.Name{
-					CommonName: "ntfy.sh",
-				},
-				NotBefore:             time.Now(),
-				NotAfter:              time.Now().Add(time.Hour),
-				KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-				ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-				BasicConstraintsValid: true,
-				DNSNames:              []string{"ntfy.sh"},
-			}
-
-			serverDerBytes, err := x509.CreateCertificate(
-				rand.Reader,
-				&serverTemplate,
-				&intermediateTemplate,
-				&privKey.PublicKey,
-				intermediatePrivKey,
-			)
-			gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-			// Create a test server with ONLY the server certificate (missing intermediate)
-			server := httptest.NewUnstartedServer(
-				http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-					response := apiResponseError{
-						Code:    http.StatusOK,
-						Message: "OK",
-					}
-
-					w.Header().Set("Content-Type", "application/json")
-					w.WriteHeader(http.StatusOK)
-					_ = json.NewEncoder(w).Encode(response)
-				}),
-			)
-			server.TLS = &tls.Config{
-				Certificates: []tls.Certificate{
-					{
-						Certificate: [][]byte{
-							serverDerBytes,
-						},
-						PrivateKey: privKey,
-					},
-				},
-			}
-			// Reference intermediateDerBytes to avoid unused variable warning
-			_ = intermediateDerBytes
-
-			server.StartTLS()
-			defer server.Close()
-
-			// Create RootCAs that only contains the root CA (not the intermediate)
-			rootCAs := x509.NewCertPool()
-			rootCert, err := x509.ParseCertificate(rootDerBytes)
-			gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-			rootCAs.AddCert(rootCert)
-
-			// Create a dedicated HTTP client with root CAs only
-			transport := &http.Transport{
-				TLSClientConfig: &tls.Config{
-					RootCAs: rootCAs,
-				},
-			}
-			client := &http.Client{Transport: transport}
-			service.SetHTTPClient(client)
-
-			// Parse the test server URL to extract host and construct ntfy URL
-			serverURL, err := url.Parse(server.URL)
-			gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-			// Create ntfy service URL pointing to the test server
-			serviceURL := testutils.URLMust(fmt.Sprintf("ntfy://%s/testtopic", serverURL.Host))
-
-			// Initialize the ntfy service with the test server URL
-			gomega.Expect(service.Initialize(serviceURL, logger)).To(gomega.Succeed())
-
-			// Attempt to send a message - this should fail because the intermediate
-			// certificate is missing from the chain
-			err = service.Send("Test message", nil)
-			gomega.Expect(err).To(gomega.HaveOccurred())
-			gomega.Expect(err.Error()).
-				To(gomega.ContainSubstring("tls: failed to verify certificate"))
-		})
-
-		ginkgo.It("should fail with network/proxy interference scenarios", func() {
-			// This test demonstrates failure when network proxies or middleboxes
-			// interfere with TLS connections by performing MITM attacks
-			privKey, err := rsa.GenerateKey(rand.Reader, 2048)
-			gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-			// Create a certificate that represents what a proxy might present
-			// (different from the expected ntfy.sh certificate)
-			template := x509.Certificate{
-				SerialNumber: big.NewInt(1),
-				Subject: pkix.Name{
-					CommonName:   "proxy.example.com", // Different hostname
-					Organization: []string{"Proxy Authority"},
-				},
-				NotBefore:             time.Now(),
-				NotAfter:              time.Now().Add(time.Hour),
-				KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-				ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-				BasicConstraintsValid: true,
-				DNSNames:              []string{"proxy.example.com"},
-			}
-
-			derBytes, err := x509.CreateCertificate(
-				rand.Reader,
-				&template,
-				&template,
-				&privKey.PublicKey,
-				privKey,
-			)
-			gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-			// Create a test server with the proxy certificate
-			server := httptest.NewUnstartedServer(
-				http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-					// Simulate proxy interference - might return different response
-					response := apiResponseError{
-						Code:    http.StatusOK,
-						Message: "Intercepted by proxy",
-					}
-
-					w.Header().Set("Content-Type", "application/json")
-					w.WriteHeader(http.StatusOK)
-					_ = json.NewEncoder(w).Encode(response)
-				}),
-			)
-			server.TLS = &tls.Config{
-				Certificates: []tls.Certificate{
-					{
-						Certificate: [][]byte{derBytes},
-						PrivateKey:  privKey,
-					},
-				},
-			}
-
-			server.StartTLS()
-			defer server.Close()
-
-			// Parse the test server URL to extract host and construct ntfy URL
-			serverURL, err := url.Parse(server.URL)
-			gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-			// Create ntfy service URL pointing to the test server
-			// Note: We're connecting to proxy.example.com but expecting ntfy.sh
-			serviceURL := testutils.URLMust(fmt.Sprintf("ntfy://%s/testtopic", serverURL.Host))
-
-			// Initialize the ntfy service with the test server URL
-			gomega.Expect(service.Initialize(serviceURL, logger)).To(gomega.Succeed())
-
-			// Attempt to send a message - this should fail because the certificate
-			// doesn't match the expected hostname (simulating proxy interference)
-			err = service.Send("Test message", nil)
-			gomega.Expect(err).To(gomega.HaveOccurred())
-			gomega.Expect(err.Error()).
-				To(gomega.ContainSubstring("tls: failed to verify certificate"))
-		})
-
-		ginkgo.It(
-			"should succeed with properly configured TLS and valid certificate chain",
-			func() {
-				// This test demonstrates what SHOULD work - proper TLS configuration
-				// with a complete certificate chain that includes all intermediates
-				privKey, err := rsa.GenerateKey(rand.Reader, 2048)
-				gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-				// Create root CA certificate
-				rootTemplate := x509.Certificate{
-					SerialNumber: big.NewInt(0),
-					Subject: pkix.Name{
-						CommonName:   "Test Root CA",
-						Organization: []string{"Test Certificate Authority"},
-					},
-					NotBefore:             time.Now().AddDate(-1, 0, 0),
-					NotAfter:              time.Now().AddDate(5, 0, 0),
-					KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
-					BasicConstraintsValid: true,
-					IsCA:                  true,
-				}
-
-				rootPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
-				gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-				rootDerBytes, err := x509.CreateCertificate(
-					rand.Reader,
-					&rootTemplate,
-					&rootTemplate,
-					&rootPrivKey.PublicKey,
-					rootPrivKey,
-				)
-				gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-				// Create intermediate CA certificate
-				intermediateTemplate := x509.Certificate{
-					SerialNumber: big.NewInt(1),
-					Subject: pkix.Name{
-						CommonName:   "Test Intermediate CA",
-						Organization: []string{"Test Certificate Authority"},
-					},
-					NotBefore:             time.Now().AddDate(-1, 0, 0),
-					NotAfter:              time.Now().AddDate(2, 0, 0),
-					KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
-					BasicConstraintsValid: true,
-					IsCA:                  true,
-				}
-
-				intermediatePrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
-				gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-				intermediateDerBytes, err := x509.CreateCertificate(
-					rand.Reader,
-					&intermediateTemplate,
-					&rootTemplate,
-					&intermediatePrivKey.PublicKey,
-					rootPrivKey,
-				)
-				gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-				// Create server certificate signed by intermediate CA
-				serverTemplate := x509.Certificate{
-					SerialNumber: big.NewInt(2),
-					Subject: pkix.Name{
-						CommonName: "127.0.0.1",
-					},
-					NotBefore:             time.Now(),
-					NotAfter:              time.Now().Add(time.Hour),
-					KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-					ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-					BasicConstraintsValid: true,
-					IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
-				}
-
-				serverDerBytes, err := x509.CreateCertificate(
-					rand.Reader,
-					&serverTemplate,
-					&intermediateTemplate,
-					&privKey.PublicKey,
-					intermediatePrivKey,
-				)
-				gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-				// Create a test server with the complete certificate chain
-				server := httptest.NewUnstartedServer(
-					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-						response := apiResponseError{
-							Code:    http.StatusOK,
-							Message: "OK",
-						}
-
-						w.Header().Set("Content-Type", "application/json")
-						w.WriteHeader(http.StatusOK)
-						_ = json.NewEncoder(w).Encode(response)
-					}),
-				)
-				server.TLS = &tls.Config{
-					Certificates: []tls.Certificate{
-						{
-							Certificate: [][]byte{
-								serverDerBytes,
-								intermediateDerBytes,
-								rootDerBytes,
-							}, // Complete chain
-							PrivateKey: privKey,
-						},
-					},
-				}
-
-				server.StartTLS()
-				defer server.Close()
-
-				// Create a dedicated HTTP client with minimum TLS version 1.2 and proper RootCAs
-				rootCAs := x509.NewCertPool()
-				rootCert, err := x509.ParseCertificate(rootDerBytes)
-				// Add debug logging for the test setup
-				service.Logf(
-					"DEBUG: Test setup - server certificate chain length: %d",
-					len(server.TLS.Certificates[0].Certificate),
-				)
-
-				if len(server.TLS.Certificates[0].Certificate) > 0 {
-					cert, err := x509.ParseCertificate(server.TLS.Certificates[0].Certificate[0])
-					if err == nil {
-						service.Logf(
-							"DEBUG: Server cert subject: %s, issuer: %s",
-							cert.Subject.CommonName,
-							cert.Issuer.CommonName,
-						)
-					}
-				}
-
-				gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-				rootCAs.AddCert(rootCert)
-
-				transport := &http.Transport{
-					TLSClientConfig: &tls.Config{
-						MinVersion: tls.VersionTLS12,
-						RootCAs:    rootCAs,
-					},
-				}
-				client := &http.Client{Transport: transport}
-
-				// Parse the test server URL to extract host and construct ntfy URL
-				serverURL, err := url.Parse(server.URL)
-				gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-				// Create ntfy service URL pointing to the test server
-				serviceURL := testutils.URLMust(fmt.Sprintf("ntfy://%s/testtopic", serverURL.Host))
-
-				// Initialize the ntfy service with the test server URL
-				gomega.Expect(service.Initialize(serviceURL, logger)).To(gomega.Succeed())
-
-				service.SetHTTPClient(client)
-
-				// Attempt to send a message - this should succeed because we have
-				// the complete certificate chain and proper RootCAs configured
-				gomega.Expect(service.Send("Test message", nil)).To(gomega.Succeed())
-			},
-		)
-
-		ginkgo.It(
-			"should succeed with default Go RootCAs when certificate is properly trusted",
-			func() {
-				// This test demonstrates success with Go's default RootCAs
-				// using httptest.NewTLSServer which provides a properly trusted certificate
-				server := httptest.NewTLSServer(
-					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-						response := apiResponseError{
-							Code:    http.StatusOK,
-							Message: "OK",
-						}
-
-						w.Header().Set("Content-Type", "application/json")
-						w.WriteHeader(http.StatusOK)
-						_ = json.NewEncoder(w).Encode(response)
-					}),
-				)
-				defer server.Close()
-
-				// Parse the test server URL to extract host and construct ntfy URL
-				serverURL, err := url.Parse(server.URL)
-				gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-				// Create ntfy service URL pointing to the test server
-				serviceURL := testutils.URLMust(fmt.Sprintf("ntfy://%s/testtopic", serverURL.Host))
-
-				// Initialize the ntfy service with the test server URL
-				gomega.Expect(service.Initialize(serviceURL, logger)).To(gomega.Succeed())
-
-				// Configure HTTP client to trust the test server's certificate
-				certPool := x509.NewCertPool()
-				certPool.AddCert(server.Certificate())
-				transport := &http.Transport{
-					TLSClientConfig: &tls.Config{
-						RootCAs: certPool,
-					},
-				}
-				client := &http.Client{Transport: transport}
-				service.SetHTTPClient(client)
-
-				// Attempt to send a message - this should succeed because the certificate is now trusted
-				gomega.Expect(service.Send("Test message", nil)).To(gomega.Succeed())
-			},
-		)
-
-		ginkgo.It(
-			"should fail when server uses TLS 1.0 and client requires minimum TLS 1.2",
-			func() {
-				// This test demonstrates that TLS certificate verification can fail even with valid certificates
-				// when the server uses a TLS version below the client's minimum required version.
-				// This highlights another aspect of TLS issues that can cause certificate verification failures.
-				privKey, err := rsa.GenerateKey(rand.Reader, 2048)
-				gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-				template := x509.Certificate{
-					SerialNumber: big.NewInt(1),
-					Subject: pkix.Name{
-						Organization: []string{"Test Organization"},
-					},
-					NotBefore:             time.Now(),
-					NotAfter:              time.Now().Add(time.Hour),
-					KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-					ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-					BasicConstraintsValid: true,
-					IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
-				}
-
-				derBytes, err := x509.CreateCertificate(
-					rand.Reader,
-					&template,
-					&template,
-					&privKey.PublicKey,
-					privKey,
-				)
-				gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-				// Create a test server that only supports TLS 1.0
-				server := httptest.NewUnstartedServer(
-					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-						response := apiResponseError{
-							Code:    http.StatusOK,
-							Message: "OK",
-						}
-
-						w.Header().Set("Content-Type", "application/json")
-						w.WriteHeader(http.StatusOK)
-						_ = json.NewEncoder(w).Encode(response)
-					}),
-				)
-				server.TLS = &tls.Config{
-					Certificates: []tls.Certificate{
-						{
-							Certificate: [][]byte{derBytes},
-							PrivateKey:  privKey,
-						},
-					},
-					// Force server to use only TLS 1.0
-					MinVersion: tls.VersionTLS10,
-					MaxVersion: tls.VersionTLS10,
-				}
-
-				server.StartTLS()
-				defer server.Close()
-
-				// Create a dedicated HTTP client with minimum TLS version 1.2
-				transport := &http.Transport{
-					TLSClientConfig: &tls.Config{
-						MinVersion: tls.VersionTLS12,
-					},
-				}
-				client := &http.Client{Transport: transport}
-				service.SetHTTPClient(client)
-
-				// Parse the test server URL to extract host and construct ntfy URL
-				serverURL, err := url.Parse(server.URL)
-				gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-				// Create ntfy service URL pointing to the test server
-				serviceURL := testutils.URLMust(fmt.Sprintf("ntfy://%s/testtopic", serverURL.Host))
-
-				// Initialize the ntfy service with the test server URL
-				gomega.Expect(service.Initialize(serviceURL, logger)).To(gomega.Succeed())
-
-				// Attempt to send a message - this should fail because the server only supports TLS 1.0
-				// but the client requires minimum TLS 1.2
-				err = service.Send("Test message", nil)
-				gomega.Expect(err).To(gomega.HaveOccurred())
-				gomega.Expect(err.Error()).
-					To(gomega.ContainSubstring("tls: protocol version not supported"))
-			},
-		)
-
-		ginkgo.It(
-			"should fail when server uses TLS 1.1 and client requires minimum TLS 1.2",
-			func() {
-				// This test demonstrates that TLS certificate verification can fail even with valid certificates
-				// when the server uses TLS 1.1 but the client requires minimum TLS 1.2.
-				// This is another common cause of TLS handshake failures that appear as certificate verification errors.
-				privKey, err := rsa.GenerateKey(rand.Reader, 2048)
-				gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-				template := x509.Certificate{
-					SerialNumber: big.NewInt(1),
-					Subject: pkix.Name{
-						Organization: []string{"Test Organization"},
-					},
-					NotBefore:             time.Now(),
-					NotAfter:              time.Now().Add(time.Hour),
-					KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-					ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-					BasicConstraintsValid: true,
-					IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
-				}
-
-				derBytes, err := x509.CreateCertificate(
-					rand.Reader,
-					&template,
-					&template,
-					&privKey.PublicKey,
-					privKey,
-				)
-				gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-				// Create a test server that only supports TLS 1.1
-				server := httptest.NewUnstartedServer(
-					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-						response := apiResponseError{
-							Code:    http.StatusOK,
-							Message: "OK",
-						}
-
-						w.Header().Set("Content-Type", "application/json")
-						w.WriteHeader(http.StatusOK)
-						_ = json.NewEncoder(w).Encode(response)
-					}),
-				)
-				server.TLS = &tls.Config{
-					Certificates: []tls.Certificate{
-						{
-							Certificate: [][]byte{derBytes},
-							PrivateKey:  privKey,
-						},
-					},
-					// Force server to use only TLS 1.1
-					MinVersion: tls.VersionTLS11,
-					MaxVersion: tls.VersionTLS11,
-				}
-
-				server.StartTLS()
-				defer server.Close()
-
-				// Create a dedicated HTTP client with minimum TLS version 1.2
-				certPool := x509.NewCertPool()
-				certPool.AddCert(server.Certificate())
-				transport := &http.Transport{
-					TLSClientConfig: &tls.Config{
-						MinVersion: tls.VersionTLS12,
-						RootCAs:    certPool,
-					},
-				}
-				client := &http.Client{Transport: transport}
-
-				// Parse the test server URL to extract host and construct ntfy URL
-				serverURL, err := url.Parse(server.URL)
-				gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-				// Create ntfy service URL pointing to the test server
-				serviceURL := testutils.URLMust(fmt.Sprintf("ntfy://%s/testtopic", serverURL.Host))
-
-				// Initialize the ntfy service with the test server URL
-				gomega.Expect(service.Initialize(serviceURL, logger)).To(gomega.Succeed())
-
-				service.SetHTTPClient(client)
-
-				// Attempt to send a message - this should fail because the server only supports TLS 1.1
-				// but the client requires minimum TLS 1.2
-				err = service.Send("Test message", nil)
-				gomega.Expect(err).To(gomega.HaveOccurred())
-				gomega.Expect(err.Error()).
-					To(gomega.ContainSubstring("tls: protocol version not supported"))
-			},
-		)
-
-		ginkgo.It(
-			"should succeed when server uses TLS 1.2 and client requires minimum TLS 1.2",
-			func() {
-				// This test demonstrates successful TLS connection when both server and client
-				// support TLS 1.2 as the minimum version requirement.
-				privKey, err := rsa.GenerateKey(rand.Reader, 2048)
-				gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-				template := x509.Certificate{
-					SerialNumber: big.NewInt(1),
-					Subject: pkix.Name{
-						Organization: []string{"Test Organization"},
-					},
-					NotBefore:             time.Now(),
-					NotAfter:              time.Now().Add(time.Hour),
-					KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-					ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-					BasicConstraintsValid: true,
-					IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
-				}
-
-				derBytes, err := x509.CreateCertificate(
-					rand.Reader,
-					&template,
-					&template,
-					&privKey.PublicKey,
-					privKey,
-				)
-				gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-				// Create a test server that supports TLS 1.2
-				server := httptest.NewUnstartedServer(
-					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-						response := apiResponseError{
-							Code:    http.StatusOK,
-							Message: "OK",
-						}
-
-						w.Header().Set("Content-Type", "application/json")
-						w.WriteHeader(http.StatusOK)
-						_ = json.NewEncoder(w).Encode(response)
-					}),
-				)
-				server.TLS = &tls.Config{
-					Certificates: []tls.Certificate{
-						{
-							Certificate: [][]byte{derBytes},
-							PrivateKey:  privKey,
-						},
-					},
-					// Server supports TLS 1.2 and above
-					MinVersion: tls.VersionTLS12,
-				}
-
-				server.StartTLS()
-				defer server.Close()
-
-				// Create a dedicated HTTP client with minimum TLS version 1.2
-				certPool := x509.NewCertPool()
-				certPool.AddCert(server.Certificate())
-				transport := &http.Transport{
-					TLSClientConfig: &tls.Config{
-						MinVersion: tls.VersionTLS12,
-						RootCAs:    certPool,
-					},
-				}
-				client := &http.Client{Transport: transport}
-
-				// Parse the test server URL to extract host and construct ntfy URL
-				serverURL, err := url.Parse(server.URL)
-				gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-				// Create ntfy service URL pointing to the test server
-				serviceURL := testutils.URLMust(fmt.Sprintf("ntfy://%s/testtopic", serverURL.Host))
-
-				// Initialize the ntfy service with the test server URL
-				gomega.Expect(service.Initialize(serviceURL, logger)).To(gomega.Succeed())
-
-				service.SetHTTPClient(client)
-
-				// Attempt to send a message - this should succeed because both server and client
-				// support TLS 1.2 as the minimum version
-				gomega.Expect(service.Send("Test message", nil)).To(gomega.Succeed())
-			},
-		)
-
-		ginkgo.It(
-			"should succeed when server supports TLS 1.2+ and client requires minimum TLS 1.2",
-			func() {
-				// This test demonstrates successful TLS connection when the server supports TLS 1.2+
-				// and the client requires minimum TLS 1.2 (TLS 1.3 is negotiated when available).
-				privKey, err := rsa.GenerateKey(rand.Reader, 2048)
-				gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-				template := x509.Certificate{
-					SerialNumber: big.NewInt(1),
-					Subject: pkix.Name{
-						Organization: []string{"Test Organization"},
-					},
-					NotBefore:             time.Now(),
-					NotAfter:              time.Now().Add(time.Hour),
-					KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-					ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-					BasicConstraintsValid: true,
-					IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
-				}
-
-				derBytes, err := x509.CreateCertificate(
-					rand.Reader,
-					&template,
-					&template,
-					&privKey.PublicKey,
-					privKey,
-				)
-				gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-				// Create a test server that supports TLS 1.2+
-				server := httptest.NewUnstartedServer(
-					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-						response := apiResponseError{
-							Code:    http.StatusOK,
-							Message: "OK",
-						}
-
-						w.Header().Set("Content-Type", "application/json")
-						w.WriteHeader(http.StatusOK)
-						_ = json.NewEncoder(w).Encode(response)
-					}),
-				)
-				server.TLS = &tls.Config{
-					Certificates: []tls.Certificate{
-						{
-							Certificate: [][]byte{derBytes},
-							PrivateKey:  privKey,
-						},
-					},
-					// Server supports TLS 1.2 and above, negotiating to 1.3 when available
-					MinVersion: tls.VersionTLS12,
-				}
-
-				server.StartTLS()
-				defer server.Close()
-
-				// Create a dedicated HTTP client with InsecureSkipVerify to allow version negotiation
-				transport := &http.Transport{
-					TLSClientConfig: &tls.Config{
-						InsecureSkipVerify: true,
-					},
-				}
-				client := &http.Client{Transport: transport}
-
-				// Parse the test server URL to extract host and construct ntfy URL
-				serverURL, err := url.Parse(server.URL)
-				gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-				// Create ntfy service URL pointing to the test server
-				serviceURL := testutils.URLMust(fmt.Sprintf("ntfy://%s/testtopic", serverURL.Host))
-
-				// Initialize the ntfy service with the test server URL
-				gomega.Expect(service.Initialize(serviceURL, logger)).To(gomega.Succeed())
-
-				service.SetHTTPClient(client)
-
-				// Attempt to send a message - this should succeed because TLS 1.3 is compatible
-				// with a minimum requirement of TLS 1.2
-				gomega.Expect(service.Send("Test message", nil)).To(gomega.Succeed())
-			},
-		)
-
-		ginkgo.It(
-			"should demonstrate the impact of different MinVersion settings on TLS connections",
-			func() {
-				// This test demonstrates how different MinVersion settings affect TLS connections.
-				// It shows that even with valid certificates, TLS version requirements can cause
-				// connection failures that manifest as certificate verification errors.
-				privKey, err := rsa.GenerateKey(rand.Reader, 2048)
-				gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-				template := x509.Certificate{
-					SerialNumber: big.NewInt(1),
-					Subject: pkix.Name{
-						Organization: []string{"Test Organization"},
-					},
-					NotBefore:             time.Now(),
-					NotAfter:              time.Now().Add(time.Hour),
-					KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-					ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-					BasicConstraintsValid: true,
-					IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
-				}
-
-				derBytes, err := x509.CreateCertificate(
-					rand.Reader,
-					&template,
-					&template,
-					&privKey.PublicKey,
-					privKey,
-				)
-				gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-				// Create a test server that supports only TLS 1.2
-				server := httptest.NewUnstartedServer(
-					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-						response := apiResponseError{
-							Code:    http.StatusOK,
-							Message: "OK",
-						}
-
-						w.Header().Set("Content-Type", "application/json")
-						w.WriteHeader(http.StatusOK)
-						_ = json.NewEncoder(w).Encode(response)
-					}),
-				)
-				server.TLS = &tls.Config{
-					Certificates: []tls.Certificate{
-						{
-							Certificate: [][]byte{derBytes},
-							PrivateKey:  privKey,
-						},
-					},
-					// Server supports only TLS 1.2
-					MinVersion: tls.VersionTLS12,
-					MaxVersion: tls.VersionTLS12,
-				}
-
-				server.StartTLS()
-				defer server.Close()
-
-				// Parse the test server URL to extract host and construct ntfy URL
-				serverURL, err := url.Parse(server.URL)
-				gomega.Expect(err).To(gomega.Not(gomega.HaveOccurred()))
-
-				serviceURL := testutils.URLMust(fmt.Sprintf("ntfy://%s/testtopic", serverURL.Host))
-
-				// Test 1: MinVersion = TLS 1.3 should fail against TLS 1.2 server
-				certPool := x509.NewCertPool()
-				certPool.AddCert(server.Certificate())
-				transport13 := &http.Transport{
-					TLSClientConfig: &tls.Config{
-						MinVersion: tls.VersionTLS13,
-						RootCAs:    certPool,
-					},
-				}
-				// Add debug logging for TLS version test
-				service.Logf(
-					"DEBUG: TLS version test - client MinVersion: %v, server MinVersion: %v, MaxVersion: %v",
-					transport13.TLSClientConfig.MinVersion,
-					server.TLS.MinVersion,
-					server.TLS.MaxVersion,
-				)
-				client13 := &http.Client{Transport: transport13}
-
-				gomega.Expect(service.Initialize(serviceURL, logger)).To(gomega.Succeed())
-				service.SetHTTPClient(client13)
-				err = service.Send("Test message with TLS 1.3 min requirement", nil)
-				gomega.Expect(err).To(gomega.HaveOccurred())
-				gomega.Expect(err.Error()).
-					To(gomega.ContainSubstring("tls: protocol version not supported"))
-
-				// Test 2: MinVersion = TLS 1.2 should succeed against TLS 1.2 server
-				transport12 := &http.Transport{
-					TLSClientConfig: &tls.Config{
-						MinVersion: tls.VersionTLS12,
-						RootCAs:    certPool,
-					},
-				}
-				client12 := &http.Client{Transport: transport12}
-
-				gomega.Expect(service.Initialize(serviceURL, logger)).To(gomega.Succeed())
-				service.SetHTTPClient(client12)
-				gomega.Expect(service.Send("Test message with TLS 1.2 min requirement", nil)).
-					To(gomega.Succeed())
-			},
-		)
-	})
-
-	ginkgo.Describe("service identification", func() {
-		ginkgo.It("should return the correct service ID", func() {
-			service := &Service{}
-			gomega.Expect(service.GetID()).To(gomega.Equal("ntfy"))
 		})
 	})
 
-	ginkgo.Describe("TLS configuration", func() {
-		ginkgo.Describe("DisableTLSVerification", func() {
-			ginkgo.It(
-				"should set InsecureSkipVerify when DisableTLSVerification is true",
-				func() {
-					svc := &Service{}
-					serviceURL := testutils.URLMust(
-						"ntfy://example.com/test?disabletlsverification=yes",
-					)
-					gomega.Expect(svc.Initialize(serviceURL, logger)).To(gomega.Succeed())
-
-					transport := svc.httpClient.(*http.Client).Transport.(*http.Transport)
-					gomega.Expect(transport.TLSClientConfig.InsecureSkipVerify).To(gomega.BeTrue())
-				},
-			)
-
-			ginkgo.It("should log warning when DisableTLSVerification is enabled", func() {
-				svc := &Service{}
-				serviceURL := testutils.URLMust(
-					"ntfy://example.com/test?disabletlsverification=yes",
-				)
-				gomega.Expect(svc.Initialize(serviceURL, logger)).To(gomega.Succeed())
-				gomega.Expect(svc.Config.DisableTLSVerification).To(gomega.BeTrue())
-			})
-
-			ginkgo.It(
-				"should not set InsecureSkipVerify when DisableTLSVerification is false",
-				func() {
-					svc := &Service{}
-					serviceURL := testutils.URLMust("ntfy://example.com/test")
-					gomega.Expect(svc.Initialize(serviceURL, logger)).To(gomega.Succeed())
-
-					// Check that the HTTP client does not have InsecureSkipVerify set
-					transport := svc.httpClient.(*http.Client).Transport.(*http.Transport)
-					gomega.Expect(transport.TLSClientConfig == nil || transport.TLSClientConfig.InsecureSkipVerify == false).
-						To(gomega.BeTrue())
-				},
-			)
+	ginkgo.Describe("SetHTTPClient", func() {
+		ginkgo.It("should set the HTTP client and recreate jsonclient", func() {
+			newClient := &http.Client{}
+			service.SetHTTPClient(newClient)
+			gomega.Expect(service.httpClient).To(gomega.BeIdenticalTo(newClient))
+			gomega.Expect(service.client).NotTo(gomega.BeNil())
 		})
 
-		ginkgo.Describe("DisableTLS", func() {
-			ginkgo.It("should use HTTP scheme when DisableTLS is true", func() {
-				serviceURL := testutils.URLMust("ntfy://example.com/test?disabletls=yes")
-				gomega.Expect(service.Initialize(serviceURL, logger)).To(gomega.Succeed())
+		ginkgo.It("should not recreate jsonclient when client is nil", func() {
+			existingJSON := newMockJSONClient()
+			service.client = existingJSON
+			service.SetHTTPClient(nil)
+			gomega.Expect(service.httpClient).To(gomega.BeNil())
+			gomega.Expect(service.client).To(gomega.BeIdenticalTo(existingJSON))
+		})
+	})
 
-				gomega.Expect(service.Config.GetAPIURL()).
-					To(gomega.Equal("http://example.com/test"))
-			})
+	ginkgo.Describe("sendAPI", func() {
+		var headers http.Header
 
-			ginkgo.It("should use HTTPS scheme when DisableTLS is false", func() {
-				config := &Config{
-					Host:       "example.com",
-					Topic:      "test",
-					Scheme:     "https",
-					DisableTLS: false,
-				}
-				gomega.Expect(config.GetAPIURL()).To(gomega.Equal("https://example.com/test"))
-			})
+		ginkgo.BeforeEach(func() {
+			service.Config = &Config{
+				Scheme: "https",
+				Host:   "ntfy.example.com",
+				Topic:  "mytopic",
+			}
+			headers = http.Header{}
+			mockJSON.On("Headers").Return(headers)
+		})
+
+		ginkgo.It("should set Content-Type to text/plain by default", func() {
+			mockJSON.On("Post", mock.Anything, mock.Anything, mock.Anything).
+				Return(nil)
+
+			err := service.sendAPI(service.Config, "hello")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(headers.Get("Content-Type")).To(gomega.Equal("text/plain; charset=utf-8"))
+		})
+
+		ginkgo.It("should set Content-Type to text/markdown when Markdown is enabled", func() {
+			service.Config.Markdown = true
+
+			mockJSON.On("Post", mock.Anything, mock.Anything, mock.Anything).
+				Return(nil)
+
+			err := service.sendAPI(service.Config, "**hello**")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(headers.Get("Content-Type")).To(gomega.Equal("text/markdown"))
+		})
+
+		ginkgo.It("should set Content-Type to text/plain when Markdown is disabled", func() {
+			service.Config.Markdown = false
+
+			mockJSON.On("Post", mock.Anything, mock.Anything, mock.Anything).
+				Return(nil)
+
+			err := service.sendAPI(service.Config, "hello")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(headers.Get("Content-Type")).To(gomega.Equal("text/plain; charset=utf-8"))
+		})
+
+		ginkgo.It("should set User-Agent header with shoutrrr version", func() {
+			mockJSON.On("Post", mock.Anything, mock.Anything, mock.Anything).
+				Return(nil)
+
+			err := service.sendAPI(service.Config, "hello")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(headers.Get("User-Agent")).To(gomega.ContainSubstring("shoutrrr/"))
+		})
+
+		ginkgo.It("should set Title header when configured", func() {
+			service.Config.Title = "Alert"
+
+			mockJSON.On("Post", mock.Anything, mock.Anything, mock.Anything).
+				Return(nil)
+
+			err := service.sendAPI(service.Config, "hello")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(headers.Get("Title")).To(gomega.Equal("Alert"))
+		})
+
+		ginkgo.It("should set Priority header when configured", func() {
+			service.Config.Priority = PriorityHigh
+
+			mockJSON.On("Post", mock.Anything, mock.Anything, mock.Anything).
+				Return(nil)
+
+			err := service.sendAPI(service.Config, "hello")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(headers.Get("Priority")).To(gomega.Equal("High"))
+		})
+
+		ginkgo.It("should set Tags header as comma-separated list", func() {
+			service.Config.Tags = []string{"warning", "skull"}
+
+			mockJSON.On("Post", mock.Anything, mock.Anything, mock.Anything).
+				Return(nil)
+
+			err := service.sendAPI(service.Config, "hello")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(headers.Get("Tags")).To(gomega.Equal("warning,skull"))
+		})
+
+		ginkgo.It("should set Basic Auth header when username and password are provided", func() {
+			service.Config.Username = "user"
+			service.Config.Password = "pass"
+
+			mockJSON.On("Post", mock.Anything, mock.Anything, mock.Anything).
+				Return(nil)
+
+			err := service.sendAPI(service.Config, "hello")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(headers.Get("Authorization")).To(gomega.HavePrefix("Basic "))
+		})
+
+		ginkgo.It("should skip Cache header when Cache is disabled", func() {
+			service.Config.Cache = false
+
+			mockJSON.On("Post", mock.Anything, mock.Anything, mock.Anything).
+				Return(nil)
+
+			err := service.sendAPI(service.Config, "hello")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(headers.Get("Cache")).To(gomega.Equal("no"))
+		})
+
+		ginkgo.It("should skip Firebase header when Firebase is disabled", func() {
+			service.Config.Firebase = false
+
+			mockJSON.On("Post", mock.Anything, mock.Anything, mock.Anything).
+				Return(nil)
+
+			err := service.sendAPI(service.Config, "hello")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(headers.Get("Firebase")).To(gomega.Equal("no"))
+		})
+
+		ginkgo.It("should set Actions header when configured", func() {
+			service.Config.Actions = []string{"view", "open"}
+
+			mockJSON.On("Post", mock.Anything, mock.Anything, mock.Anything).
+				Return(nil)
+
+			err := service.sendAPI(service.Config, "hello")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(headers.Get("Actions")).To(gomega.Equal("view;open"))
+		})
+
+		ginkgo.It("should set Delay header when configured", func() {
+			service.Config.Delay = "2h"
+
+			mockJSON.On("Post", mock.Anything, mock.Anything, mock.Anything).
+				Return(nil)
+
+			err := service.sendAPI(service.Config, "hello")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(headers.Get("Delay")).To(gomega.Equal("2h"))
+		})
+
+		ginkgo.It("should set Click header when configured", func() {
+			service.Config.Click = "https://example.com"
+
+			mockJSON.On("Post", mock.Anything, mock.Anything, mock.Anything).
+				Return(nil)
+
+			err := service.sendAPI(service.Config, "hello")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(headers.Get("Click")).To(gomega.Equal("https://example.com"))
+		})
+
+		ginkgo.It("should set Attach header when configured", func() {
+			service.Config.Attach = "https://example.com/image.png"
+
+			mockJSON.On("Post", mock.Anything, mock.Anything, mock.Anything).
+				Return(nil)
+
+			err := service.sendAPI(service.Config, "hello")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(headers.Get("Attach")).To(gomega.Equal("https://example.com/image.png"))
+		})
+
+		ginkgo.It("should set X-Icon header when configured", func() {
+			service.Config.Icon = "https://example.com/icon.png"
+
+			mockJSON.On("Post", mock.Anything, mock.Anything, mock.Anything).
+				Return(nil)
+
+			err := service.sendAPI(service.Config, "hello")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(headers.Get("X-Icon")).To(gomega.Equal("https://example.com/icon.png"))
+		})
+
+		ginkgo.It("should set Filename header when configured", func() {
+			service.Config.Filename = "document.pdf"
+
+			mockJSON.On("Post", mock.Anything, mock.Anything, mock.Anything).
+				Return(nil)
+
+			err := service.sendAPI(service.Config, "hello")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(headers.Get("Filename")).To(gomega.Equal("document.pdf"))
+		})
+
+		ginkgo.It("should set Email header when configured", func() {
+			service.Config.Email = "user@example.com"
+
+			mockJSON.On("Post", mock.Anything, mock.Anything, mock.Anything).
+				Return(nil)
+
+			err := service.sendAPI(service.Config, "hello")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(headers.Get("Email")).To(gomega.Equal("user@example.com"))
+		})
+
+		ginkgo.It("should call Post with the API URL and message body", func() {
+			mockJSON.On("Post", service.Config.GetAPIURL(), "hello", mock.Anything).
+				Return(nil)
+
+			err := service.sendAPI(service.Config, "hello")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should set Basic Auth header with username only", func() {
+			service.Config.Username = "user"
+			service.Config.Password = ""
+
+			mockJSON.On("Post", mock.Anything, mock.Anything, mock.Anything).
+				Return(nil)
+
+			err := service.sendAPI(service.Config, "hello")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(headers.Get("Authorization")).To(gomega.HavePrefix("Basic "))
+		})
+
+		ginkgo.It("should set Basic Auth header with password only", func() {
+			service.Config.Username = ""
+			service.Config.Password = "pass"
+
+			mockJSON.On("Post", mock.Anything, mock.Anything, mock.Anything).
+				Return(nil)
+
+			err := service.sendAPI(service.Config, "hello")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(headers.Get("Authorization")).To(gomega.HavePrefix("Basic "))
+		})
+
+		ginkgo.It("should send empty message without error", func() {
+			mockJSON.On("Post", mock.Anything, mock.Anything, mock.Anything).
+				Return(nil)
+
+			err := service.sendAPI(service.Config, "")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should set single tag without comma separator", func() {
+			service.Config.Tags = []string{"warning"}
+
+			mockJSON.On("Post", mock.Anything, mock.Anything, mock.Anything).
+				Return(nil)
+
+			err := service.sendAPI(service.Config, "hello")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(headers.Get("Tags")).To(gomega.Equal("warning"))
+		})
+
+		ginkgo.It("should return error when Post fails", func() {
+			mockJSON.On("Post", mock.Anything, mock.Anything, mock.Anything).
+				Return(io.ErrClosedPipe)
+			mockJSON.On("ErrorResponse", mock.Anything, mock.Anything).
+				Return(false)
+
+			err := service.sendAPI(service.Config, "hello")
+			gomega.Expect(err).To(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should return apiResponseError when API returns structured error", func() {
+			responseBody := `{"code":400,"error":"invalid request","link":"https://docs.ntfy.sh"}`
+
+			mockJSON.On("Post", mock.Anything, mock.Anything, mock.Anything).
+				Return(jsonclient.Error{
+					StatusCode: 400,
+					Body:       responseBody,
+				})
+			mockJSON.EXPECT().ErrorResponse(mock.Anything, mock.Anything).
+				RunAndReturn(func(_ error, response any) bool {
+					if resp, ok := response.(*apiResponseError); ok {
+						resp.Code = 400
+						resp.Message = "invalid request"
+						resp.Link = "https://docs.ntfy.sh"
+					}
+
+					return true
+				})
+
+			err := service.sendAPI(service.Config, "hello")
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("invalid request"))
+		})
+
+		ginkgo.It("should return wrapped error when Post fails and ErrorResponse parsing fails", func() {
+			mockJSON.On("Post", mock.Anything, mock.Anything, mock.Anything).
+				Return(io.ErrClosedPipe)
+			mockJSON.On("ErrorResponse", mock.Anything, mock.Anything).
+				Return(false)
+
+			err := service.sendAPI(service.Config, "hello")
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("posting to ntfy API"))
 		})
 	})
 })
 
-func TestNtfy(t *testing.T) {
-	t.Parallel()
+var _ = ginkgo.Describe("addHeaderIfNotEmpty", func() {
+	ginkgo.It("should add header when value is non-empty", func() {
+		headers := http.Header{}
+		addHeaderIfNotEmpty(&headers, "X-Test", "value")
+		gomega.Expect(headers.Get("X-Test")).To(gomega.Equal("value"))
+	})
 
-	gomegaformat.CharactersAroundMismatchToInclude = 20
+	ginkgo.It("should not add header when value is empty", func() {
+		headers := http.Header{}
+		addHeaderIfNotEmpty(&headers, "X-Test", "")
+		gomega.Expect(headers.Get("X-Test")).To(gomega.Equal(""))
+	})
 
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Shoutrrr Ntfy Suite")
-}
+	ginkgo.It("should append multiple values for the same header", func() {
+		headers := http.Header{}
+		addHeaderIfNotEmpty(&headers, "X-Test", "value1")
+		addHeaderIfNotEmpty(&headers, "X-Test", "value2")
+		gomega.Expect(headers["X-Test"]).To(gomega.Equal([]string{"value1", "value2"}))
+	})
+})
+
+var _ = ginkgo.Describe("TLS configuration", func() {
+	var (
+		svc        *Service
+		testLogger types.StdLogger
+	)
+
+	ginkgo.BeforeEach(func() {
+		testLogger = &noOpLogger{}
+	})
+
+	ginkgo.Describe("DisableTLSVerification", func() {
+		ginkgo.It("should set InsecureSkipVerify when DisableTLSVerification is true", func() {
+			svc = &Service{}
+			serviceURL := mustParseURL("ntfy://example.com/test?disabletlsverification=yes")
+			gomega.Expect(svc.Initialize(serviceURL, testLogger)).To(gomega.Succeed())
+			transport := svc.httpClient.(*http.Client).Transport.(*http.Transport)
+			gomega.Expect(transport.TLSClientConfig.InsecureSkipVerify).To(gomega.BeTrue())
+		})
+
+		ginkgo.It("should set DisableTLSVerification config when enabled", func() {
+			svc = &Service{}
+			serviceURL := mustParseURL("ntfy://example.com/test?disabletlsverification=yes")
+			gomega.Expect(svc.Initialize(serviceURL, testLogger)).To(gomega.Succeed())
+			gomega.Expect(svc.Config.DisableTLSVerification).To(gomega.BeTrue())
+		})
+
+		ginkgo.It("should not set InsecureSkipVerify when DisableTLSVerification is false", func() {
+			svc = &Service{}
+			serviceURL := mustParseURL("ntfy://example.com/test")
+			gomega.Expect(svc.Initialize(serviceURL, testLogger)).To(gomega.Succeed())
+			transport := svc.httpClient.(*http.Client).Transport.(*http.Transport)
+			gomega.Expect(transport.TLSClientConfig.InsecureSkipVerify).To(gomega.BeFalse())
+		})
+	})
+
+	ginkgo.Describe("DisableTLS", func() {
+		ginkgo.It("should use HTTP scheme when DisableTLS is true", func() {
+			svc = &Service{}
+			serviceURL := mustParseURL("ntfy://example.com/test?disabletls=yes")
+			gomega.Expect(svc.Initialize(serviceURL, testLogger)).To(gomega.Succeed())
+			gomega.Expect(svc.Config.GetAPIURL()).To(gomega.Equal("http://example.com/test"))
+		})
+
+		ginkgo.It("should use HTTPS scheme when DisableTLS is false", func() {
+			config := &Config{
+				Host:       "example.com",
+				Topic:      "test",
+				Scheme:     "https",
+				DisableTLS: false,
+			}
+			gomega.Expect(config.GetAPIURL()).To(gomega.Equal("https://example.com/test"))
+		})
+	})
+})
+
+var _ = ginkgo.Describe("service identification", func() {
+	ginkgo.It("should return the correct service ID", func() {
+		svc := &Service{}
+		gomega.Expect(svc.GetID()).To(gomega.Equal(Scheme))
+	})
+})
+
+var _ = ginkgo.Describe("service API compliance", func() {
+	var (
+		svc        *Service
+		testLogger types.StdLogger
+	)
+
+	ginkgo.BeforeEach(func() {
+		testLogger = &noOpLogger{}
+	})
+
+	ginkgo.It("should pass config API compliance checks", func() {
+		testutils.TestConfigSetInvalidQueryValue(&Config{}, "ntfy://host/topic?foo=bar")
+		testutils.TestConfigGetInvalidQueryValue(&Config{})
+		testutils.TestConfigSetDefaultValues(&Config{})
+		testutils.TestConfigGetEnumsCount(&Config{}, 1)
+		testutils.TestConfigGetFieldsCount(&Config{}, 18)
+	})
+
+	ginkgo.It("should pass service API compliance checks", func() {
+		svc = &Service{}
+		serviceURL := mustParseURL("ntfy://:devicekey@hostname/testtopic")
+		gomega.Expect(svc.Initialize(serviceURL, testLogger)).To(gomega.Succeed())
+		testutils.TestServiceSetInvalidParamValue(svc, "foo", "bar")
+	})
+})

--- a/testing/e2e/ntfy/.gitignore
+++ b/testing/e2e/ntfy/.gitignore
@@ -1,0 +1,3 @@
+# ntfy E2E Test Environment
+/data/*
+.env

--- a/testing/e2e/ntfy/README.md
+++ b/testing/e2e/ntfy/README.md
@@ -1,0 +1,238 @@
+# ntfy End-to-End Tests
+
+This directory contains end-to-end (e2e) tests for the ntfy service in Shoutrrr.
+
+## Overview
+
+The end-to-end tests validate the complete ntfy notification functionality by sending messages to a real ntfy server and verifying they are received.
+
+## Test Coverage
+
+### Basic Message Functionality
+
+- Plain text messages
+- Empty messages
+- Message delivery verification via ntfy API
+
+### Message Features
+
+- Title
+- Priority levels
+- Tags/emojis
+- Markdown formatting
+- Click actions
+- Attachments
+- Action buttons
+- Delayed delivery
+- Email notifications
+- Icon
+- Filename
+- Multiple tags
+- Combined parameters
+
+### Configuration
+
+- Default configuration
+- URL-based configuration
+- Priority from URL
+- Markdown from URL
+- Tags from URL
+- Title from URL
+- DisableTLS from URL
+
+### Authentication
+
+- Basic authentication with username and password
+- Username-only authentication
+
+### TLS
+
+- HTTPS connections (default)
+- HTTP connections with DisableTLS
+
+## Setup Requirements
+
+### ntfy Server
+
+A local ntfy server is required for e2e testing. The provided `docker-compose.yaml` sets up a local ntfy server.
+
+### Prerequisites
+
+- Go 1.25+
+- Docker and Docker Compose
+- Linux OS
+
+### Quick Start
+
+1. Start the ntfy server using docker compose:
+
+    ```bash
+    cd testing/e2e/ntfy
+    docker compose up -d
+    ```
+
+2. Wait for the server to be ready:
+
+    ```bash
+    ./setup.sh setup-all
+    ```
+
+3. Run the e2e tests:
+
+    ```bash
+    go test -v ./testing/e2e/ntfy/...
+    ```
+
+### ntfy Server Details
+
+| Field   | Value                             |
+|---------|-----------------------------------|
+| Host    | localhost                         |
+| Port    | 8080                              |
+| API URL | <http://localhost:8080>           |
+| Health  | <http://localhost:8080/v1/health> |
+
+### Stopping the Server
+
+To stop the ntfy server:
+
+```bash
+cd testing/e2e/ntfy
+docker compose down
+```
+
+## Environment Variables
+
+A `.env` file is provided with preconfigured defaults.
+
+**Default values:**
+**Security Note**: Never commit real credentials to version control. The `.env` file is in `.gitignore`.
+
+```bash
+# Required: ntfy server URL
+SHOUTRRR_NTFY_URL=ntfy://localhost:8080/shoutrrr-e2e-test
+
+# Optional: ntfy server authentication
+# SHOUTRRR_NTFY_USERNAME=
+# SHOUTRRR_NTFY_PASSWORD=
+
+# Optional: TLS configuration
+# SHOUTRRR_NTFY_DISABLE_TLS=false
+```
+
+## Running the Tests
+
+### Test Execution Prerequisites
+
+- Go 1.25+
+- Running ntfy server
+- `.env` file with required environment variables
+
+### Execute E2E Tests
+
+Run all e2e tests:
+
+```bash
+go test ./testing/e2e/ntfy/ -v
+```
+
+Run specific test files:
+
+```bash
+# Test basic functionality
+go test ./testing/e2e/ntfy/ -v -args -ginkgo.focus="basic"
+
+# Test configuration
+go test ./testing/e2e/ntfy/ -v -args -ginkgo.focus="config"
+
+# Test message features
+go test ./testing/e2e/ntfy/ -v -args -ginkgo.focus="message"
+
+# Test authentication
+go test ./testing/e2e/ntfy/ -v -args -ginkgo.focus="auth"
+
+# Test TLS
+go test ./testing/e2e/ntfy/ -v -args -ginkgo.focus="TLS"
+```
+
+### Test Behavior
+
+- Tests will skip if the ntfy server is not available
+- Tests include delays between executions to respect ntfy rate limits
+- All tests send actual messages to the ntfy server
+- Messages are verified via the ntfy API polling endpoint
+- Each test includes an "E2E Test:" prefix to identify test messages
+
+### Message Verification
+
+The e2e tests verify message delivery by polling the ntfy API:
+
+1. A message is sent to a unique topic
+2. The test polls `GET /<topic>/json?poll=1&message=<message>` to retrieve the message
+3. The response is parsed as JSON and verified against expected values
+
+## Test Structure
+
+```bash
+testing/e2e/ntfy/
+├── .env                 # Environment variables (not committed)
+├── .gitignore           # Git ignore rules
+├── docker-compose.yaml  # ntfy server setup (Docker Compose)
+├── setup.sh             # Setup script for starting/stopping the server
+├── suite_test.go        # Test suite setup and configuration
+├── basic_test.go        # Basic message sending functionality
+├── config_test.go       # Configuration tests
+├── message_features_test.go # Message features (title, priority, tags, etc.)
+├── authentication_test.go   # Authentication tests
+├── tls_test.go          # TLS connection tests
+└── README.md            # This file
+```
+
+### Test Organization
+
+Each test file focuses on a specific feature category:
+
+- **Basic Tests** (`basic_test.go`): Core message sending functionality
+- **Config Tests** (`config_test.go`): Configuration options and URL parsing
+- **Message Features Tests** (`message_features_test.go`): Rich message features
+- **Authentication Tests** (`authentication_test.go`): Basic auth handling
+- **TLS Tests** (`tls_test.go`): TLS/HTTP connection handling
+
+## ntfy URL Examples
+
+### Basic Connection
+
+```bash
+SHOUTRRR_NTFY_URL=ntfy://localhost:8080/shoutrrr-e2e-test
+```
+
+### With Authentication
+
+```bash
+SHOUTRRR_NTFY_URL=ntfy://username:password@localhost:8080/shoutrrr-e2e-test
+```
+
+### With Priority
+
+```bash
+SHOUTRRR_NTFY_URL=ntfy://localhost:8080/shoutrrr-e2e-test?priority=5
+```
+
+### With Tags
+
+```bash
+SHOUTRRR_NTFY_URL=ntfy://localhost:8080/shoutrrr-e2e-test?tags=warning,skull
+```
+
+### With HTTP (DisableTLS)
+
+```bash
+SHOUTRRR_NTFY_URL=ntfy://localhost:8080/shoutrrr-e2e-test
+SHOUTRRR_NTFY_DISABLE_TLS=true
+```
+
+## Resources
+
+- ntfy Documentation: <https://docs.ntfy.sh>
+- ntfy Docker Image: <https://hub.docker.com/r/binwiederhier/ntfy>
+- ntfy GitHub: <https://github.com/binwiederhier/ntfy>

--- a/testing/e2e/ntfy/README.md
+++ b/testing/e2e/ntfy/README.md
@@ -64,20 +64,14 @@ A local ntfy server is required for e2e testing. The provided `docker-compose.ya
 
 ### Quick Start
 
-1. Start the ntfy server using docker compose:
+1. Start the ntfy server and wait for it to be ready using the setup script:
 
     ```bash
     cd testing/e2e/ntfy
-    docker compose up -d
-    ```
-
-2. Wait for the server to be ready:
-
-    ```bash
     ./setup.sh setup-all
     ```
 
-3. Run the e2e tests:
+2. Run the e2e tests:
 
     ```bash
     go test -v ./testing/e2e/ntfy/...

--- a/testing/e2e/ntfy/authentication_test.go
+++ b/testing/e2e/ntfy/authentication_test.go
@@ -1,0 +1,79 @@
+package e2e_test
+
+import (
+	"net/url"
+	"os"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	"github.com/nicholas-fedor/shoutrrr/internal/testutils"
+	"github.com/nicholas-fedor/shoutrrr/pkg/services/push/ntfy"
+)
+
+var _ = ginkgo.Describe("ntfy E2E Authentication Tests", func() {
+	ginkgo.When("running e2e tests against a real ntfy server", func() {
+		ginkgo.BeforeEach(func() {
+			if !isNtfyServerAvailable() {
+				ginkgo.Skip("ntfy server not available, skipping e2e tests")
+			}
+		})
+
+		ginkgo.It("should send a message with basic authentication", func() {
+			username := os.Getenv("SHOUTRRR_NTFY_USERNAME")
+			password := os.Getenv("SHOUTRRR_NTFY_PASSWORD")
+
+			if username == "" || password == "" {
+				ginkgo.Skip("ntfy credentials not configured, skipping auth test")
+			}
+
+			serviceURLStr := buildServiceURL()
+			serviceURL, err := url.Parse(serviceURLStr)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			service := &ntfy.Service{}
+			err = service.Initialize(serviceURL, testutils.TestLogger())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			topic := service.Config.Topic
+			message := "E2E Test: Authenticated message"
+
+			err = service.Send(message, nil)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			verifyMessageReceived(topic, message)
+		})
+
+		ginkgo.It("should send a message with username-only authentication", func() {
+			username := os.Getenv("SHOUTRRR_NTFY_USERNAME")
+			password := os.Getenv("SHOUTRRR_NTFY_PASSWORD")
+
+			if username == "" || password != "" {
+				ginkgo.Skip("username-only auth not configured, skipping test")
+			}
+
+			serviceURLStr := buildServiceURL()
+			serviceURL, err := url.Parse(serviceURLStr)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			service := &ntfy.Service{}
+			err = service.Initialize(serviceURL, testutils.TestLogger())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			topic := service.Config.Topic
+			message := "E2E Test: Username-only auth message"
+
+			err = service.Send(message, nil)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			verifyMessageReceived(topic, message)
+		})
+	})
+
+	ginkgo.When("no server is configured", func() {
+		ginkgo.It("should return the correct service ID", func() {
+			service := &ntfy.Service{}
+			gomega.Expect(service.GetID()).To(gomega.Equal("ntfy"))
+		})
+	})
+})

--- a/testing/e2e/ntfy/authentication_test.go
+++ b/testing/e2e/ntfy/authentication_test.go
@@ -1,13 +1,11 @@
 package e2e_test
 
 import (
-	"net/url"
 	"os"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
-	"github.com/nicholas-fedor/shoutrrr/internal/testutils"
 	"github.com/nicholas-fedor/shoutrrr/pkg/services/push/ntfy"
 )
 
@@ -28,18 +26,12 @@ var _ = ginkgo.Describe("ntfy E2E Authentication Tests", func() {
 			}
 
 			serviceURLStr := buildServiceURL()
-			serviceURL, err := url.Parse(serviceURLStr)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			service := &ntfy.Service{}
-			err = service.Initialize(serviceURL, testutils.TestLogger())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			service := initializeService(serviceURLStr)
 
 			topic := service.Config.Topic
 			message := "E2E Test: Authenticated message"
 
-			err = service.Send(message, nil)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(service.Send(message, nil)).NotTo(gomega.HaveOccurred())
 
 			verifyMessageReceived(topic, message)
 		})
@@ -53,18 +45,12 @@ var _ = ginkgo.Describe("ntfy E2E Authentication Tests", func() {
 			}
 
 			serviceURLStr := buildServiceURL()
-			serviceURL, err := url.Parse(serviceURLStr)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			service := &ntfy.Service{}
-			err = service.Initialize(serviceURL, testutils.TestLogger())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			service := initializeService(serviceURLStr)
 
 			topic := service.Config.Topic
 			message := "E2E Test: Username-only auth message"
 
-			err = service.Send(message, nil)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(service.Send(message, nil)).NotTo(gomega.HaveOccurred())
 
 			verifyMessageReceived(topic, message)
 		})

--- a/testing/e2e/ntfy/basic_test.go
+++ b/testing/e2e/ntfy/basic_test.go
@@ -19,13 +19,14 @@ import (
 )
 
 type ntfyMessage struct {
-	ID       string   `json:"id"`
-	Event    string   `json:"event"`
-	Topic    string   `json:"topic"`
-	Message  string   `json:"message"`
-	Title    string   `json:"title"`
-	Priority int      `json:"priority"`
-	Tags     []string `json:"tags"`
+	ID          string   `json:"id"`
+	Event       string   `json:"event"`
+	Topic       string   `json:"topic"`
+	Message     string   `json:"message"`
+	Title       string   `json:"title"`
+	Priority    int      `json:"priority"`
+	Tags        []string `json:"tags"`
+	ContentType string   `json:"content_type"`
 }
 
 const defaultMessageTimeout = 5 * time.Second
@@ -135,7 +136,12 @@ var _ = ginkgo.Describe("ntfy E2E Basic Tests", func() {
 
 			gomega.Expect(service.Send(message, nil)).NotTo(gomega.HaveOccurred())
 
-			verifyMessageReceived(topic, message)
+			msg, err := pollForMessage(topic, message)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "message should be received by ntfy server")
+			gomega.Expect(msg).NotTo(gomega.BeNil())
+			gomega.Expect(msg.Event).To(gomega.Equal("message"))
+			gomega.Expect(msg.Topic).To(gomega.ContainSubstring(topic))
+			gomega.Expect(msg.ContentType).To(gomega.Equal("text/markdown"), "received event should reflect Markdown Content-Type")
 		})
 
 		ginkgo.It("should send a message with special characters and unicode", func() {

--- a/testing/e2e/ntfy/basic_test.go
+++ b/testing/e2e/ntfy/basic_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
-	"github.com/nicholas-fedor/shoutrrr/internal/testutils"
 	"github.com/nicholas-fedor/shoutrrr/pkg/services/push/ntfy"
 	"github.com/nicholas-fedor/shoutrrr/pkg/types"
 )
@@ -45,17 +44,11 @@ var _ = ginkgo.Describe("ntfy E2E Basic Tests", func() {
 				ginkgo.Skip("ntfy server not configured, skipping basic text test")
 			}
 
-			serviceURL, err := url.Parse(serviceURLStr)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			service := &ntfy.Service{}
-			err = service.Initialize(serviceURL, testutils.TestLogger())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			service := initializeService(serviceURLStr)
 
 			message := "E2E Test: Basic text content notification"
 
-			err = service.Send(message, nil)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(service.Send(message, nil)).NotTo(gomega.HaveOccurred())
 
 			verifyMessageReceived(service.Config.Topic, message)
 		})
@@ -66,15 +59,9 @@ var _ = ginkgo.Describe("ntfy E2E Basic Tests", func() {
 				ginkgo.Skip("ntfy server not configured, skipping empty message test")
 			}
 
-			serviceURL, err := url.Parse(serviceURLStr)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			service := initializeService(serviceURLStr)
 
-			service := &ntfy.Service{}
-			err = service.Initialize(serviceURL, testutils.TestLogger())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			err = service.Send("", nil)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(service.Send("", nil)).NotTo(gomega.HaveOccurred())
 
 			ginkgo.GinkgoWriter.Write([]byte("Empty message sent successfully\n"))
 		})
@@ -85,21 +72,15 @@ var _ = ginkgo.Describe("ntfy E2E Basic Tests", func() {
 				ginkgo.Skip("ntfy server not configured, skipping title test")
 			}
 
-			serviceURL, err := url.Parse(serviceURLStr)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			service := &ntfy.Service{}
-			err = service.Initialize(serviceURL, testutils.TestLogger())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			service := initializeService(serviceURLStr)
 
 			topic := service.Config.Topic
 			message := "E2E Test: Message with title"
 			expectedTitle := "Test Title"
 
-			err = service.Send(message, &types.Params{
+			gomega.Expect(service.Send(message, &types.Params{
 				"title": expectedTitle,
-			})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			})).NotTo(gomega.HaveOccurred())
 
 			verifyMessageReceivedWithTitle(topic, message, expectedTitle)
 		})
@@ -110,20 +91,14 @@ var _ = ginkgo.Describe("ntfy E2E Basic Tests", func() {
 				ginkgo.Skip("ntfy server not configured, skipping priority test")
 			}
 
-			serviceURL, err := url.Parse(serviceURLStr)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			service := &ntfy.Service{}
-			err = service.Initialize(serviceURL, testutils.TestLogger())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			service := initializeService(serviceURLStr)
 
 			topic := service.Config.Topic
 			message := "E2E Test: High priority message"
 
-			err = service.Send(message, &types.Params{
+			gomega.Expect(service.Send(message, &types.Params{
 				"priority": "5",
-			})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			})).NotTo(gomega.HaveOccurred())
 
 			verifyMessageReceivedWithPriority(topic, message, 5)
 		})
@@ -134,20 +109,14 @@ var _ = ginkgo.Describe("ntfy E2E Basic Tests", func() {
 				ginkgo.Skip("ntfy server not configured, skipping tags test")
 			}
 
-			serviceURL, err := url.Parse(serviceURLStr)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			service := &ntfy.Service{}
-			err = service.Initialize(serviceURL, testutils.TestLogger())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			service := initializeService(serviceURLStr)
 
 			topic := service.Config.Topic
 			message := "E2E Test: Tagged message"
 
-			err = service.Send(message, &types.Params{
+			gomega.Expect(service.Send(message, &types.Params{
 				"tags": "warning,skull",
-			})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			})).NotTo(gomega.HaveOccurred())
 
 			verifyMessageReceivedWithTags(topic, message, []string{"warning", "skull"})
 		})
@@ -159,18 +128,12 @@ var _ = ginkgo.Describe("ntfy E2E Basic Tests", func() {
 			}
 
 			serviceURLStr += "&markdown=yes"
-			serviceURL, err := url.Parse(serviceURLStr)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			service := &ntfy.Service{}
-			err = service.Initialize(serviceURL, testutils.TestLogger())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			service := initializeService(serviceURLStr)
 
 			topic := service.Config.Topic
 			message := "E2E Test: **bold** and *italic* markdown"
 
-			err = service.Send(message, nil)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(service.Send(message, nil)).NotTo(gomega.HaveOccurred())
 
 			verifyMessageReceived(topic, message)
 		})
@@ -181,18 +144,12 @@ var _ = ginkgo.Describe("ntfy E2E Basic Tests", func() {
 				ginkgo.Skip("ntfy server not configured, skipping unicode test")
 			}
 
-			serviceURL, err := url.Parse(serviceURLStr)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			service := &ntfy.Service{}
-			err = service.Initialize(serviceURL, testutils.TestLogger())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			service := initializeService(serviceURLStr)
 
 			topic := service.Config.Topic
 			message := "E2E Test: Special chars <>@#$% and unicode 世界 🌍"
 
-			err = service.Send(message, nil)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(service.Send(message, nil)).NotTo(gomega.HaveOccurred())
 
 			verifyMessageReceived(topic, message)
 		})

--- a/testing/e2e/ntfy/basic_test.go
+++ b/testing/e2e/ntfy/basic_test.go
@@ -1,0 +1,288 @@
+package e2e_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	"github.com/nicholas-fedor/shoutrrr/internal/testutils"
+	"github.com/nicholas-fedor/shoutrrr/pkg/services/push/ntfy"
+	"github.com/nicholas-fedor/shoutrrr/pkg/types"
+)
+
+type ntfyMessage struct {
+	ID       string   `json:"id"`
+	Event    string   `json:"event"`
+	Topic    string   `json:"topic"`
+	Message  string   `json:"message"`
+	Title    string   `json:"title"`
+	Priority int      `json:"priority"`
+	Tags     []string `json:"tags"`
+}
+
+const defaultMessageTimeout = 5 * time.Second
+
+var _ = ginkgo.Describe("ntfy E2E Basic Tests", func() {
+	ginkgo.When("running e2e tests against a real ntfy server", func() {
+		ginkgo.BeforeEach(func() {
+			if !isNtfyServerAvailable() {
+				ginkgo.Skip("ntfy server not available, skipping e2e tests")
+			}
+		})
+
+		ginkgo.It("should send basic text content", func() {
+			serviceURLStr := buildServiceURL()
+			if serviceURLStr == "" {
+				ginkgo.Skip("ntfy server not configured, skipping basic text test")
+			}
+
+			serviceURL, err := url.Parse(serviceURLStr)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			service := &ntfy.Service{}
+			err = service.Initialize(serviceURL, testutils.TestLogger())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			message := "E2E Test: Basic text content notification"
+
+			err = service.Send(message, nil)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			verifyMessageReceived(service.Config.Topic, message)
+		})
+
+		ginkgo.It("should send an empty message", func() {
+			serviceURLStr := buildServiceURL()
+			if serviceURLStr == "" {
+				ginkgo.Skip("ntfy server not configured, skipping empty message test")
+			}
+
+			serviceURL, err := url.Parse(serviceURLStr)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			service := &ntfy.Service{}
+			err = service.Initialize(serviceURL, testutils.TestLogger())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			err = service.Send("", nil)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.GinkgoWriter.Write([]byte("Empty message sent successfully\n"))
+		})
+
+		ginkgo.It("should send a message with a title via params", func() {
+			serviceURLStr := buildServiceURL()
+			if serviceURLStr == "" {
+				ginkgo.Skip("ntfy server not configured, skipping title test")
+			}
+
+			serviceURL, err := url.Parse(serviceURLStr)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			service := &ntfy.Service{}
+			err = service.Initialize(serviceURL, testutils.TestLogger())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			topic := service.Config.Topic
+			message := "E2E Test: Message with title"
+			expectedTitle := "Test Title"
+
+			err = service.Send(message, &types.Params{
+				"title": expectedTitle,
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			verifyMessageReceivedWithTitle(topic, message, expectedTitle)
+		})
+
+		ginkgo.It("should send a message with priority via params", func() {
+			serviceURLStr := buildServiceURL()
+			if serviceURLStr == "" {
+				ginkgo.Skip("ntfy server not configured, skipping priority test")
+			}
+
+			serviceURL, err := url.Parse(serviceURLStr)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			service := &ntfy.Service{}
+			err = service.Initialize(serviceURL, testutils.TestLogger())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			topic := service.Config.Topic
+			message := "E2E Test: High priority message"
+
+			err = service.Send(message, &types.Params{
+				"priority": "5",
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			verifyMessageReceivedWithPriority(topic, message, 5)
+		})
+
+		ginkgo.It("should send a message with tags", func() {
+			serviceURLStr := buildServiceURL()
+			if serviceURLStr == "" {
+				ginkgo.Skip("ntfy server not configured, skipping tags test")
+			}
+
+			serviceURL, err := url.Parse(serviceURLStr)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			service := &ntfy.Service{}
+			err = service.Initialize(serviceURL, testutils.TestLogger())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			topic := service.Config.Topic
+			message := "E2E Test: Tagged message"
+
+			err = service.Send(message, &types.Params{
+				"tags": "warning,skull",
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			verifyMessageReceivedWithTags(topic, message, []string{"warning", "skull"})
+		})
+
+		ginkgo.It("should send a message with markdown", func() {
+			serviceURLStr := buildServiceURL()
+			if serviceURLStr == "" {
+				ginkgo.Skip("ntfy server not configured, skipping markdown test")
+			}
+
+			serviceURLStr += "&markdown=yes"
+			serviceURL, err := url.Parse(serviceURLStr)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			service := &ntfy.Service{}
+			err = service.Initialize(serviceURL, testutils.TestLogger())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			topic := service.Config.Topic
+			message := "E2E Test: **bold** and *italic* markdown"
+
+			err = service.Send(message, nil)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			verifyMessageReceived(topic, message)
+		})
+
+		ginkgo.It("should send a message with special characters and unicode", func() {
+			serviceURLStr := buildServiceURL()
+			if serviceURLStr == "" {
+				ginkgo.Skip("ntfy server not configured, skipping unicode test")
+			}
+
+			serviceURL, err := url.Parse(serviceURLStr)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			service := &ntfy.Service{}
+			err = service.Initialize(serviceURL, testutils.TestLogger())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			topic := service.Config.Topic
+			message := "E2E Test: Special chars <>@#$% and unicode 世界 🌍"
+
+			err = service.Send(message, nil)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			verifyMessageReceived(topic, message)
+		})
+	})
+
+	ginkgo.When("no server is configured", func() {
+		ginkgo.It("should return the correct service ID", func() {
+			service := &ntfy.Service{}
+			gomega.Expect(service.GetID()).To(gomega.Equal("ntfy"))
+		})
+	})
+})
+
+func pollForMessage(topic, expectedMessage string) (*ntfyMessage, error) {
+	baseURL := getNtfyBaseURL()
+	apiURL := fmt.Sprintf("%s/%s/json?poll=1&message=%s", baseURL, topic, url.QueryEscape(expectedMessage))
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultMessageTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	client := &http.Client{Timeout: defaultMessageTimeout}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("making request: %w", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	lines := strings.SplitSeq(strings.TrimSpace(string(body)), "\n")
+	for line := range lines {
+		if line == "" {
+			continue
+		}
+
+		var msg ntfyMessage
+		if err := json.Unmarshal([]byte(line), &msg); err != nil {
+			continue
+		}
+
+		if msg.Message == expectedMessage {
+			return &msg, nil
+		}
+	}
+
+	return nil, errors.New("message not found in response")
+}
+
+func verifyMessageReceived(topic, message string) {
+	msg, err := pollForMessage(topic, message)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "message should be received by ntfy server")
+	gomega.Expect(msg).NotTo(gomega.BeNil())
+	gomega.Expect(msg.Event).To(gomega.Equal("message"))
+	gomega.Expect(msg.Topic).To(gomega.ContainSubstring(topic))
+}
+
+func verifyMessageReceivedWithTitle(topic, message, expectedTitle string) {
+	msg, err := pollForMessage(topic, message)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "message should be received by ntfy server")
+	gomega.Expect(msg).NotTo(gomega.BeNil())
+	gomega.Expect(msg.Event).To(gomega.Equal("message"))
+	gomega.Expect(msg.Title).To(gomega.Equal(expectedTitle))
+}
+
+func verifyMessageReceivedWithPriority(topic, message string, expectedPriority int) {
+	msg, err := pollForMessage(topic, message)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "message should be received by ntfy server")
+	gomega.Expect(msg).NotTo(gomega.BeNil())
+	gomega.Expect(msg.Event).To(gomega.Equal("message"))
+	gomega.Expect(msg.Priority).To(gomega.Equal(expectedPriority))
+}
+
+func verifyMessageReceivedWithTags(topic, message string, expectedTags []string) {
+	msg, err := pollForMessage(topic, message)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "message should be received by ntfy server")
+	gomega.Expect(msg).NotTo(gomega.BeNil())
+	gomega.Expect(msg.Event).To(gomega.Equal("message"))
+	gomega.Expect(msg.Tags).To(gomega.ConsistOf(expectedTags))
+}

--- a/testing/e2e/ntfy/config_test.go
+++ b/testing/e2e/ntfy/config_test.go
@@ -1,0 +1,124 @@
+package e2e_test
+
+import (
+	"net/url"
+	"os"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	"github.com/nicholas-fedor/shoutrrr/internal/testutils"
+	"github.com/nicholas-fedor/shoutrrr/pkg/services/push/ntfy"
+)
+
+var _ = ginkgo.Describe("ntfy E2E Config Tests", func() {
+	ginkgo.When("running e2e tests against a real ntfy server", func() {
+		ginkgo.BeforeEach(func() {
+			if !isNtfyServerAvailable() {
+				ginkgo.Skip("ntfy server not available, skipping e2e tests")
+			}
+		})
+
+		ginkgo.It("should initialize with default configuration", func() {
+			serviceURLStr := buildServiceURL()
+			serviceURL, err := url.Parse(serviceURLStr)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			service := &ntfy.Service{}
+			err = service.Initialize(serviceURL, testutils.TestLogger())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			gomega.Expect(service.Config.Topic).NotTo(gomega.BeEmpty())
+			gomega.Expect(service.Config.Host).NotTo(gomega.BeEmpty())
+		})
+
+		ginkgo.It("should initialize with credentials from URL", func() {
+			serviceURLStr := buildServiceURL()
+			serviceURL, err := url.Parse(serviceURLStr)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			service := &ntfy.Service{}
+			err = service.Initialize(serviceURL, testutils.TestLogger())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			username := os.Getenv("SHOUTRRR_NTFY_USERNAME")
+			password := os.Getenv("SHOUTRRR_NTFY_PASSWORD")
+
+			if username != "" {
+				gomega.Expect(service.Config.Username).To(gomega.Equal(username))
+			}
+
+			if password != "" {
+				gomega.Expect(service.Config.Password).To(gomega.Equal(password))
+			}
+		})
+
+		ginkgo.It("should initialize with DisableTLS when configured", func() {
+			serviceURLStr := buildServiceURL()
+			serviceURL, err := url.Parse(serviceURLStr)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			service := &ntfy.Service{}
+			err = service.Initialize(serviceURL, testutils.TestLogger())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			gomega.Expect(service.Config.DisableTLS).To(gomega.BeTrue())
+			gomega.Expect(service.Config.Scheme).To(gomega.Equal("http"))
+		})
+
+		ginkgo.It("should initialize with priority from URL", func() {
+			serviceURLStr := addQueryParam(buildServiceURL(), "priority", "Max")
+			serviceURL, err := url.Parse(serviceURLStr)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			service := &ntfy.Service{}
+			err = service.Initialize(serviceURL, testutils.TestLogger())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			gomega.Expect(service.Config.Priority.String()).To(gomega.Equal("Max"))
+		})
+
+		ginkgo.It("should initialize with markdown enabled from URL", func() {
+			serviceURLStr := addQueryParam(buildServiceURL(), "markdown", "yes")
+			serviceURL, err := url.Parse(serviceURLStr)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			service := &ntfy.Service{}
+			err = service.Initialize(serviceURL, testutils.TestLogger())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			gomega.Expect(service.Config.Markdown).To(gomega.BeTrue())
+		})
+
+		ginkgo.It("should initialize with tags from URL", func() {
+			serviceURLStr := addQueryParam(buildServiceURL(), "tags", "warning,skull")
+			serviceURL, err := url.Parse(serviceURLStr)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			service := &ntfy.Service{}
+			err = service.Initialize(serviceURL, testutils.TestLogger())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			gomega.Expect(service.Config.Tags).To(gomega.ConsistOf("warning", "skull"))
+		})
+
+		ginkgo.It("should initialize with title from URL", func() {
+			serviceURLStr := addQueryParam(buildServiceURL(), "title", "MyTitle")
+			serviceURL, err := url.Parse(serviceURLStr)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			service := &ntfy.Service{}
+			err = service.Initialize(serviceURL, testutils.TestLogger())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			gomega.Expect(service.Config.Title).To(gomega.Equal("MyTitle"))
+		})
+	})
+
+	ginkgo.When("no server is configured", func() {
+		ginkgo.It("should return the correct service ID", func() {
+			service := &ntfy.Service{}
+			gomega.Expect(service.GetID()).To(gomega.Equal("ntfy"))
+		})
+	})
+})

--- a/testing/e2e/ntfy/config_test.go
+++ b/testing/e2e/ntfy/config_test.go
@@ -1,13 +1,11 @@
 package e2e_test
 
 import (
-	"net/url"
 	"os"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
-	"github.com/nicholas-fedor/shoutrrr/internal/testutils"
 	"github.com/nicholas-fedor/shoutrrr/pkg/services/push/ntfy"
 )
 
@@ -21,12 +19,7 @@ var _ = ginkgo.Describe("ntfy E2E Config Tests", func() {
 
 		ginkgo.It("should initialize with default configuration", func() {
 			serviceURLStr := buildServiceURL()
-			serviceURL, err := url.Parse(serviceURLStr)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			service := &ntfy.Service{}
-			err = service.Initialize(serviceURL, testutils.TestLogger())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			service := initializeService(serviceURLStr)
 
 			gomega.Expect(service.Config.Topic).NotTo(gomega.BeEmpty())
 			gomega.Expect(service.Config.Host).NotTo(gomega.BeEmpty())
@@ -34,12 +27,7 @@ var _ = ginkgo.Describe("ntfy E2E Config Tests", func() {
 
 		ginkgo.It("should initialize with credentials from URL", func() {
 			serviceURLStr := buildServiceURL()
-			serviceURL, err := url.Parse(serviceURLStr)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			service := &ntfy.Service{}
-			err = service.Initialize(serviceURL, testutils.TestLogger())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			service := initializeService(serviceURLStr)
 
 			username := os.Getenv("SHOUTRRR_NTFY_USERNAME")
 			password := os.Getenv("SHOUTRRR_NTFY_PASSWORD")
@@ -54,13 +42,19 @@ var _ = ginkgo.Describe("ntfy E2E Config Tests", func() {
 		})
 
 		ginkgo.It("should initialize with DisableTLS when configured", func() {
-			serviceURLStr := buildServiceURL()
-			serviceURL, err := url.Parse(serviceURLStr)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			previous, hadPrevious := os.LookupEnv("SHOUTRRR_NTFY_DISABLE_TLS")
+			_ = os.Setenv("SHOUTRRR_NTFY_DISABLE_TLS", "true")
 
-			service := &ntfy.Service{}
-			err = service.Initialize(serviceURL, testutils.TestLogger())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer func() {
+				if hadPrevious {
+					_ = os.Setenv("SHOUTRRR_NTFY_DISABLE_TLS", previous)
+				} else {
+					_ = os.Unsetenv("SHOUTRRR_NTFY_DISABLE_TLS")
+				}
+			}()
+
+			serviceURLStr := buildServiceURL()
+			service := initializeService(serviceURLStr)
 
 			gomega.Expect(service.Config.DisableTLS).To(gomega.BeTrue())
 			gomega.Expect(service.Config.Scheme).To(gomega.Equal("http"))
@@ -68,48 +62,28 @@ var _ = ginkgo.Describe("ntfy E2E Config Tests", func() {
 
 		ginkgo.It("should initialize with priority from URL", func() {
 			serviceURLStr := addQueryParam(buildServiceURL(), "priority", "Max")
-			serviceURL, err := url.Parse(serviceURLStr)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			service := &ntfy.Service{}
-			err = service.Initialize(serviceURL, testutils.TestLogger())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			service := initializeService(serviceURLStr)
 
 			gomega.Expect(service.Config.Priority.String()).To(gomega.Equal("Max"))
 		})
 
 		ginkgo.It("should initialize with markdown enabled from URL", func() {
 			serviceURLStr := addQueryParam(buildServiceURL(), "markdown", "yes")
-			serviceURL, err := url.Parse(serviceURLStr)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			service := &ntfy.Service{}
-			err = service.Initialize(serviceURL, testutils.TestLogger())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			service := initializeService(serviceURLStr)
 
 			gomega.Expect(service.Config.Markdown).To(gomega.BeTrue())
 		})
 
 		ginkgo.It("should initialize with tags from URL", func() {
 			serviceURLStr := addQueryParam(buildServiceURL(), "tags", "warning,skull")
-			serviceURL, err := url.Parse(serviceURLStr)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			service := &ntfy.Service{}
-			err = service.Initialize(serviceURL, testutils.TestLogger())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			service := initializeService(serviceURLStr)
 
 			gomega.Expect(service.Config.Tags).To(gomega.ConsistOf("warning", "skull"))
 		})
 
 		ginkgo.It("should initialize with title from URL", func() {
 			serviceURLStr := addQueryParam(buildServiceURL(), "title", "MyTitle")
-			serviceURL, err := url.Parse(serviceURLStr)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			service := &ntfy.Service{}
-			err = service.Initialize(serviceURL, testutils.TestLogger())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			service := initializeService(serviceURLStr)
 
 			gomega.Expect(service.Config.Title).To(gomega.Equal("MyTitle"))
 		})

--- a/testing/e2e/ntfy/docker-compose.yaml
+++ b/testing/e2e/ntfy/docker-compose.yaml
@@ -1,0 +1,29 @@
+# ntfy server for local E2E testing
+#
+# https://hub.docker.com/r/binwiederhier/ntfy
+#
+# Usage:
+#   docker compose up -d
+#
+# API endpoint: http://localhost:8080
+#
+# Note: No authentication is configured for local testing.
+
+services:
+  ntfy:
+    image: binwiederhier/ntfy:latest
+    container_name: ntfy
+    command:
+      - serve
+      - --visitor-request-limit-exempt-hosts=localhost,127.0.0.1,::1
+    ports:
+      - "8080:80"
+    volumes:
+      - ./data:/var/cache/ntfy
+    healthcheck:
+      test: [ "CMD-SHELL", "wget -q --tries=1 http://localhost:80/v1/health -O - | grep -Eo '\"healthy\"\\s*:\\s*true' || exit 1" ]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 40s
+    restart: unless-stopped

--- a/testing/e2e/ntfy/message_features_test.go
+++ b/testing/e2e/ntfy/message_features_test.go
@@ -1,0 +1,215 @@
+package e2e_test
+
+import (
+	"net/url"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	"github.com/nicholas-fedor/shoutrrr/internal/testutils"
+	"github.com/nicholas-fedor/shoutrrr/pkg/services/push/ntfy"
+	"github.com/nicholas-fedor/shoutrrr/pkg/types"
+)
+
+var _ = ginkgo.Describe("ntfy E2E Message Features Tests", func() {
+	ginkgo.When("running e2e tests against a real ntfy server", func() {
+		ginkgo.BeforeEach(func() {
+			if !isNtfyServerAvailable() {
+				ginkgo.Skip("ntfy server not available, skipping e2e tests")
+			}
+		})
+
+		ginkgo.It("should send a message with a click action", func() {
+			serviceURLStr := buildServiceURL()
+			serviceURL, err := url.Parse(serviceURLStr)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			service := &ntfy.Service{}
+			err = service.Initialize(serviceURL, testutils.TestLogger())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			topic := service.Config.Topic
+			message := "E2E Test: Click action message"
+
+			err = service.Send(message, &types.Params{
+				"click": "https://example.com",
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			verifyMessageReceived(topic, message)
+		})
+
+		ginkgo.It("should send a message with an attachment URL", func() {
+			serviceURLStr := buildServiceURL()
+			serviceURL, err := url.Parse(serviceURLStr)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			service := &ntfy.Service{}
+			err = service.Initialize(serviceURL, testutils.TestLogger())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			topic := service.Config.Topic
+			message := "E2E Test: Attachment message"
+
+			err = service.Send(message, &types.Params{
+				"attach": "https://example.com/image.png",
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			verifyMessageReceived(topic, message)
+		})
+
+		ginkgo.It("should send a message with actions", func() {
+			serviceURLStr := buildServiceURL()
+			serviceURL, err := url.Parse(serviceURLStr)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			service := &ntfy.Service{}
+			err = service.Initialize(serviceURL, testutils.TestLogger())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			topic := service.Config.Topic
+			message := "E2E Test: Actions message"
+
+			err = service.Send(message, &types.Params{
+				"actions": "action=view,label=Open,url=https://example.com",
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			verifyMessageReceived(topic, message)
+		})
+
+		ginkgo.It("should send a message with delay", func() {
+			serviceURLStr := buildServiceURL()
+			serviceURL, err := url.Parse(serviceURLStr)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			service := &ntfy.Service{}
+			err = service.Initialize(serviceURL, testutils.TestLogger())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			message := "E2E Test: Delayed message"
+
+		err = service.Send(message, &types.Params{
+			"delay": "10s",
+		})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Delayed messages may not appear immediately, so we just verify no error
+			ginkgo.GinkgoWriter.Write([]byte("Delayed message sent successfully\n"))
+		})
+
+		ginkgo.It("should send a message with email notification", func() {
+			ginkgo.Skip("email notifications require server-side configuration")
+
+			serviceURLStr := buildServiceURL()
+			serviceURL, err := url.Parse(serviceURLStr)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			service := &ntfy.Service{}
+			err = service.Initialize(serviceURL, testutils.TestLogger())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			topic := service.Config.Topic
+			message := "E2E Test: Email notification"
+
+			err = service.Send(message, &types.Params{
+				"email": "test@example.com",
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			verifyMessageReceived(topic, message)
+		})
+
+		ginkgo.It("should send a message with icon", func() {
+			serviceURLStr := buildServiceURL()
+			serviceURL, err := url.Parse(serviceURLStr)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			service := &ntfy.Service{}
+			err = service.Initialize(serviceURL, testutils.TestLogger())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			topic := service.Config.Topic
+			message := "E2E Test: Icon message"
+
+			err = service.Send(message, &types.Params{
+				"icon": "https://example.com/icon.png",
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			verifyMessageReceived(topic, message)
+		})
+
+		ginkgo.It("should send a message with filename", func() {
+			ginkgo.Skip("attachments require server-side configuration")
+
+			serviceURLStr := buildServiceURL()
+			serviceURL, err := url.Parse(serviceURLStr)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			service := &ntfy.Service{}
+			err = service.Initialize(serviceURL, testutils.TestLogger())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			topic := service.Config.Topic
+			message := "E2E Test: Filename message"
+
+			err = service.Send(message, &types.Params{
+				"filename": "report.pdf",
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			verifyMessageReceived(topic, message)
+		})
+
+		ginkgo.It("should send a message with multiple tags", func() {
+			serviceURLStr := buildServiceURL()
+			serviceURL, err := url.Parse(serviceURLStr)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			service := &ntfy.Service{}
+			err = service.Initialize(serviceURL, testutils.TestLogger())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			topic := service.Config.Topic
+			message := "E2E Test: Multiple tags message"
+
+			err = service.Send(message, &types.Params{
+				"tags": "warning,skull,fire",
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			verifyMessageReceivedWithTags(topic, message, []string{"warning", "skull", "fire"})
+		})
+
+		ginkgo.It("should send a message with combined params", func() {
+			serviceURLStr := buildServiceURL()
+			serviceURL, err := url.Parse(serviceURLStr)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			service := &ntfy.Service{}
+			err = service.Initialize(serviceURL, testutils.TestLogger())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			topic := service.Config.Topic
+			message := "E2E Test: Combined params message"
+
+			err = service.Send(message, &types.Params{
+				"title":    "Combined",
+				"priority": "5",
+				"tags":     "warning,skull",
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			verifyMessageReceivedWithTitle(topic, message, "Combined")
+		})
+	})
+
+	ginkgo.When("no server is configured", func() {
+		ginkgo.It("should return the correct service ID", func() {
+			service := &ntfy.Service{}
+			gomega.Expect(service.GetID()).To(gomega.Equal("ntfy"))
+		})
+	})
+})

--- a/testing/e2e/ntfy/message_features_test.go
+++ b/testing/e2e/ntfy/message_features_test.go
@@ -1,12 +1,9 @@
 package e2e_test
 
 import (
-	"net/url"
-
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
-	"github.com/nicholas-fedor/shoutrrr/internal/testutils"
 	"github.com/nicholas-fedor/shoutrrr/pkg/services/push/ntfy"
 	"github.com/nicholas-fedor/shoutrrr/pkg/types"
 )
@@ -21,79 +18,55 @@ var _ = ginkgo.Describe("ntfy E2E Message Features Tests", func() {
 
 		ginkgo.It("should send a message with a click action", func() {
 			serviceURLStr := buildServiceURL()
-			serviceURL, err := url.Parse(serviceURLStr)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			service := &ntfy.Service{}
-			err = service.Initialize(serviceURL, testutils.TestLogger())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			service := initializeService(serviceURLStr)
 
 			topic := service.Config.Topic
 			message := "E2E Test: Click action message"
 
-			err = service.Send(message, &types.Params{
+			gomega.Expect(service.Send(message, &types.Params{
 				"click": "https://example.com",
-			})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			})).NotTo(gomega.HaveOccurred())
 
 			verifyMessageReceived(topic, message)
 		})
 
 		ginkgo.It("should send a message with an attachment URL", func() {
 			serviceURLStr := buildServiceURL()
-			serviceURL, err := url.Parse(serviceURLStr)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			service := &ntfy.Service{}
-			err = service.Initialize(serviceURL, testutils.TestLogger())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			service := initializeService(serviceURLStr)
 
 			topic := service.Config.Topic
 			message := "E2E Test: Attachment message"
 
-			err = service.Send(message, &types.Params{
+			gomega.Expect(service.Send(message, &types.Params{
 				"attach": "https://example.com/image.png",
-			})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			})).NotTo(gomega.HaveOccurred())
 
 			verifyMessageReceived(topic, message)
 		})
 
 		ginkgo.It("should send a message with actions", func() {
 			serviceURLStr := buildServiceURL()
-			serviceURL, err := url.Parse(serviceURLStr)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			service := &ntfy.Service{}
-			err = service.Initialize(serviceURL, testutils.TestLogger())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			service := initializeService(serviceURLStr)
 
 			topic := service.Config.Topic
 			message := "E2E Test: Actions message"
 
-			err = service.Send(message, &types.Params{
+			gomega.Expect(service.Send(message, &types.Params{
 				"actions": "action=view,label=Open,url=https://example.com",
-			})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			})).NotTo(gomega.HaveOccurred())
 
 			verifyMessageReceived(topic, message)
 		})
 
 		ginkgo.It("should send a message with delay", func() {
 			serviceURLStr := buildServiceURL()
-			serviceURL, err := url.Parse(serviceURLStr)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			service := &ntfy.Service{}
-			err = service.Initialize(serviceURL, testutils.TestLogger())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			service := initializeService(serviceURLStr)
 
 			message := "E2E Test: Delayed message"
 
-		err = service.Send(message, &types.Params{
-			"delay": "10s",
-		})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(service.Send(message, &types.Params{
+				"delay": "10s",
+			})).NotTo(gomega.HaveOccurred())
 
 			// Delayed messages may not appear immediately, so we just verify no error
 			ginkgo.GinkgoWriter.Write([]byte("Delayed message sent successfully\n"))
@@ -103,40 +76,28 @@ var _ = ginkgo.Describe("ntfy E2E Message Features Tests", func() {
 			ginkgo.Skip("email notifications require server-side configuration")
 
 			serviceURLStr := buildServiceURL()
-			serviceURL, err := url.Parse(serviceURLStr)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			service := &ntfy.Service{}
-			err = service.Initialize(serviceURL, testutils.TestLogger())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			service := initializeService(serviceURLStr)
 
 			topic := service.Config.Topic
 			message := "E2E Test: Email notification"
 
-			err = service.Send(message, &types.Params{
+			gomega.Expect(service.Send(message, &types.Params{
 				"email": "test@example.com",
-			})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			})).NotTo(gomega.HaveOccurred())
 
 			verifyMessageReceived(topic, message)
 		})
 
 		ginkgo.It("should send a message with icon", func() {
 			serviceURLStr := buildServiceURL()
-			serviceURL, err := url.Parse(serviceURLStr)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			service := &ntfy.Service{}
-			err = service.Initialize(serviceURL, testutils.TestLogger())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			service := initializeService(serviceURLStr)
 
 			topic := service.Config.Topic
 			message := "E2E Test: Icon message"
 
-			err = service.Send(message, &types.Params{
+			gomega.Expect(service.Send(message, &types.Params{
 				"icon": "https://example.com/icon.png",
-			})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			})).NotTo(gomega.HaveOccurred())
 
 			verifyMessageReceived(topic, message)
 		})
@@ -145,62 +106,44 @@ var _ = ginkgo.Describe("ntfy E2E Message Features Tests", func() {
 			ginkgo.Skip("attachments require server-side configuration")
 
 			serviceURLStr := buildServiceURL()
-			serviceURL, err := url.Parse(serviceURLStr)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			service := &ntfy.Service{}
-			err = service.Initialize(serviceURL, testutils.TestLogger())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			service := initializeService(serviceURLStr)
 
 			topic := service.Config.Topic
 			message := "E2E Test: Filename message"
 
-			err = service.Send(message, &types.Params{
+			gomega.Expect(service.Send(message, &types.Params{
 				"filename": "report.pdf",
-			})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			})).NotTo(gomega.HaveOccurred())
 
 			verifyMessageReceived(topic, message)
 		})
 
 		ginkgo.It("should send a message with multiple tags", func() {
 			serviceURLStr := buildServiceURL()
-			serviceURL, err := url.Parse(serviceURLStr)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			service := &ntfy.Service{}
-			err = service.Initialize(serviceURL, testutils.TestLogger())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			service := initializeService(serviceURLStr)
 
 			topic := service.Config.Topic
 			message := "E2E Test: Multiple tags message"
 
-			err = service.Send(message, &types.Params{
+			gomega.Expect(service.Send(message, &types.Params{
 				"tags": "warning,skull,fire",
-			})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			})).NotTo(gomega.HaveOccurred())
 
 			verifyMessageReceivedWithTags(topic, message, []string{"warning", "skull", "fire"})
 		})
 
 		ginkgo.It("should send a message with combined params", func() {
 			serviceURLStr := buildServiceURL()
-			serviceURL, err := url.Parse(serviceURLStr)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			service := &ntfy.Service{}
-			err = service.Initialize(serviceURL, testutils.TestLogger())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			service := initializeService(serviceURLStr)
 
 			topic := service.Config.Topic
 			message := "E2E Test: Combined params message"
 
-			err = service.Send(message, &types.Params{
+			gomega.Expect(service.Send(message, &types.Params{
 				"title":    "Combined",
 				"priority": "5",
 				"tags":     "warning,skull",
-			})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			})).NotTo(gomega.HaveOccurred())
 
 			verifyMessageReceivedWithTitle(topic, message, "Combined")
 		})

--- a/testing/e2e/ntfy/setup.sh
+++ b/testing/e2e/ntfy/setup.sh
@@ -275,6 +275,8 @@ setup_all() {
 # =============================================================================
 
 main() {
+    load_env_file
+
     # Parse command-line arguments
     local command="setup-all"
 

--- a/testing/e2e/ntfy/setup.sh
+++ b/testing/e2e/ntfy/setup.sh
@@ -1,0 +1,322 @@
+#!/bin/bash
+#
+# ntfy E2E Test Environment Setup Script
+#
+# This script starts a local ntfy server for end-to-end testing
+# of Shoutrrr's ntfy service.
+#
+# Usage:
+#   ./setup.sh [OPTIONS] [COMMAND]
+#
+# Commands:
+#   start-server      Start the ntfy server using docker compose
+#   stop-server       Stop the ntfy server
+#   status            Check the status of the ntfy server
+#   setup-all         Start the server and wait for it to be ready (default)
+#
+# Options:
+#   --help, -h        Show this help message
+#   --verbose, -v    Enable verbose output
+#
+# Environment:
+#   The script automatically loads .env file from its directory if present.
+#   Required variables:
+#     None (uses defaults: localhost:8080)
+#
+
+set -euo pipefail
+
+# =============================================================================
+# Configuration and Constants
+# =============================================================================
+
+# Color codes for output
+readonly RED='\033[0;31m'
+readonly GREEN='\033[0;32m'
+readonly YELLOW='\033[1;33m'
+readonly BLUE='\033[0;34m'
+readonly NC='\033[0m' # No Color
+
+# Script configuration
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ENV_FILE="${SCRIPT_DIR}/.env"
+COMPOSE_FILE="${SCRIPT_DIR}/docker-compose.yaml"
+
+# Default values
+DEFAULT_NTFY_HOST="localhost:8080"
+
+# Verbose mode
+VERBOSE=false
+
+# Docker compose command (detected in check_requirements)
+COMPOSE_CMD=""
+
+# =============================================================================
+# Helper Functions
+# =============================================================================
+
+# Print an error message and exit
+error() {
+    echo -e "${RED}[ERROR]${NC} $1" >&2
+    exit 1
+}
+
+# Print an info message
+info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+# Print a warning message
+warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+# Print a debug message (only in verbose mode)
+debug() {
+    if [[ "$VERBOSE" == "true" ]]; then
+        echo -e "${BLUE}[DEBUG]${NC} $1"
+    fi
+}
+
+# Print usage information
+usage() {
+    echo "ntfy E2E Test Environment Setup Script"
+    echo ""
+    echo "This script starts a local ntfy server for end-to-end testing."
+    echo ""
+    echo "Usage:"
+    echo "  ./setup.sh [OPTIONS] [COMMAND]"
+    echo ""
+    echo "Commands:"
+    echo "  start-server      Start the ntfy server using docker compose"
+    echo "  stop-server       Stop the ntfy server"
+    echo "  status            Check the status of the ntfy server"
+    echo "  setup-all         Start the server and wait for it to be ready (default)"
+    echo ""
+    echo "Options:"
+    echo "  --help, -h       Show this help message"
+    echo "  --verbose, -v    Enable verbose output"
+    echo ""
+    echo "Examples:"
+    echo "  ./setup.sh                  # Start server and wait for readiness"
+    echo "  ./setup.sh start-server     # Start server only"
+    echo "  ./setup.sh stop-server      # Stop server"
+    echo "  ./setup.sh --verbose setup-all  # Run with verbose output"
+}
+
+# Load environment variables from .env file
+load_env_file() {
+    if [[ -f "$ENV_FILE" ]]; then
+        debug "Loading environment variables from ${ENV_FILE}"
+        set -a
+        source "$ENV_FILE"
+        set +a
+        info "Loaded environment variables from ${ENV_FILE}"
+    else
+        debug "No .env file found at ${ENV_FILE}"
+    fi
+}
+
+# Check if required commands are available
+check_requirements() {
+    local missing_cmds=()
+
+    # Check for docker
+    if ! command -v docker &> /dev/null; then
+        missing_cmds+=("docker")
+    fi
+
+    # Check for docker compose (plugin or standalone)
+    if docker compose version &> /dev/null 2>&1; then
+        COMPOSE_CMD="docker compose"
+    elif command -v docker-compose &> /dev/null; then
+        COMPOSE_CMD="docker-compose"
+    else
+        missing_cmds+=("docker-compose")
+    fi
+
+    # Check for curl
+    if ! command -v curl &> /dev/null; then
+        missing_cmds+=("curl")
+    fi
+
+    if [[ ${#missing_cmds[@]} -gt 0 ]]; then
+        error "Missing required commands: ${missing_cmds[*]}"
+    fi
+
+    debug "All required commands are available"
+    debug "Using compose command: ${COMPOSE_CMD}"
+}
+
+# Wait for the ntfy server to be ready
+wait_for_server() {
+    local base="${1:-http://${DEFAULT_NTFY_HOST}}"
+    local max_attempts="${2:-30}"
+    local attempt=1
+
+    info "Waiting for ntfy server at ${base} to be ready..."
+
+    while [[ $attempt -le $max_attempts ]]; do
+        if curl -s -o /dev/null -w "%{http_code}" "${base}/v1/health" 2>/dev/null | grep -q "200"; then
+            info "ntfy server is ready!"
+            return 0
+        fi
+
+        debug "Attempt ${attempt}/${max_attempts}: Server not ready yet..."
+        sleep 2
+        ((attempt++))
+    done
+
+    error "ntfy server did not become ready after ${max_attempts} attempts"
+}
+
+# =============================================================================
+# Setup Functions
+# =============================================================================
+
+# Start the ntfy server using docker compose
+start_server() {
+    info "Starting ntfy server..."
+
+    # Check if docker compose file exists
+    if [[ ! -f "$COMPOSE_FILE" ]]; then
+        error "Docker compose file not found at ${COMPOSE_FILE}"
+    fi
+
+    # Ensure COMPOSE_CMD is set
+    if [[ -z "$COMPOSE_CMD" ]]; then
+        check_requirements
+    fi
+
+    # Change to the script directory
+    cd "$SCRIPT_DIR"
+
+    # Stop any existing container
+    if $COMPOSE_CMD ps --status running 2>/dev/null | grep -q ntfy; then
+        info "Stopping existing ntfy container..."
+        $COMPOSE_CMD down || true
+    fi
+
+    # Start the server
+    if $COMPOSE_CMD up -d; then
+        info "ntfy server started successfully"
+        info "Server is available at http://${DEFAULT_NTFY_HOST}"
+        info "Use 'docker logs ntfy -f' to watch the logs"
+    else
+        error "Failed to start ntfy server"
+    fi
+}
+
+# Stop the ntfy server
+stop_server() {
+    info "Stopping ntfy server..."
+
+    # Ensure COMPOSE_CMD is set
+    if [[ -z "$COMPOSE_CMD" ]]; then
+        check_requirements
+    fi
+
+    # Change to the script directory
+    cd "$SCRIPT_DIR"
+
+    if $COMPOSE_CMD down; then
+        info "ntfy server stopped successfully"
+    else
+        error "Failed to stop ntfy server"
+    fi
+}
+
+# Check the status of the ntfy server
+check_status() {
+    # Ensure COMPOSE_CMD is set
+    if [[ -z "$COMPOSE_CMD" ]]; then
+        check_requirements
+    fi
+
+    # Change to the script directory
+    cd "$SCRIPT_DIR"
+
+    info "Checking ntfy server status..."
+    $COMPOSE_CMD ps
+}
+
+# Run all setup steps in order
+setup_all() {
+    info "Starting ntfy E2E test environment setup..."
+    echo ""
+
+    # Check requirements
+    check_requirements
+
+    # Step 1: Start server
+    echo ""
+    info "=== Step 1/2: Starting ntfy server ==="
+    start_server
+
+    # Step 2: Wait for server to be ready
+    echo ""
+    info "=== Step 2/2: Waiting for server to be ready ==="
+    wait_for_server "http://${DEFAULT_NTFY_HOST}"
+
+    echo ""
+    info "=========================================="
+    info "ntfy E2E test environment setup complete!"
+    info "=========================================="
+    info ""
+    info "You can now run the E2E tests with:"
+    info "  go test -v ./testing/e2e/ntfy/..."
+    info ""
+    info "To stop the server, run:"
+    info "  ${SCRIPT_DIR}/setup.sh stop-server"
+}
+
+# =============================================================================
+# Main Entry Point
+# =============================================================================
+
+main() {
+    # Parse command-line arguments
+    local command="setup-all"
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --help|-h)
+                usage
+                exit 0
+                ;;
+            --verbose|-v)
+                VERBOSE=true
+                shift
+                ;;
+            start-server|stop-server|status|setup-all)
+                command="$1"
+                shift
+                ;;
+            *)
+                error "Unknown option or command: $1"
+                ;;
+        esac
+    done
+
+    # Execute the requested command
+    case "$command" in
+        start-server)
+            check_requirements
+            start_server
+            ;;
+        stop-server)
+            check_requirements
+            stop_server
+            ;;
+        status)
+            check_requirements
+            check_status
+            ;;
+        setup-all)
+            setup_all
+            ;;
+    esac
+}
+
+# Run main function with all arguments
+main "$@"

--- a/testing/e2e/ntfy/suite_test.go
+++ b/testing/e2e/ntfy/suite_test.go
@@ -12,6 +12,9 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+
+	"github.com/nicholas-fedor/shoutrrr/internal/testutils"
+	"github.com/nicholas-fedor/shoutrrr/pkg/services/push/ntfy"
 )
 
 // envValueTrue is the string value for boolean true in environment variables.
@@ -90,6 +93,18 @@ func addQueryParam(rawURL, key, value string) string {
 	return serviceURL.String()
 }
 
+// initializeService parses a service URL string, creates an ntfy.Service, and initializes it.
+func initializeService(urlStr string) *ntfy.Service {
+	serviceURL, err := url.Parse(urlStr)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	service := &ntfy.Service{}
+	err = service.Initialize(serviceURL, testutils.TestLogger())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	return service
+}
+
 // loadEnvFile loads environment variables from a .env file.
 func loadEnvFile(filename string) {
 	file, err := os.Open(filename)
@@ -124,19 +139,24 @@ func loadEnvFile(filename string) {
 	}
 }
 
-// getNtfyBaseURL returns the base URL for the ntfy server using shared host and scheme logic.
+// getNtfyBaseURL returns the base URL for the ntfy server using the SHOUTRRR_NTFY_URL environment variable.
 func getNtfyBaseURL() string {
-	host := os.Getenv("SHOUTRRR_NTFY_HOST")
-	if host == "" {
-		host = "localhost:8080"
+	baseURL := os.Getenv("SHOUTRRR_NTFY_URL")
+	if baseURL == "" {
+		baseURL = "ntfy://localhost:8080/shoutrrr-e2e-test"
 	}
 
-	scheme := "http"
-	if os.Getenv("SHOUTRRR_NTFY_DISABLE_TLS") != envValueTrue {
-		scheme = "https"
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return "http://localhost:8080"
 	}
 
-	return scheme + "://" + host
+	scheme := "https"
+	if os.Getenv("SHOUTRRR_NTFY_DISABLE_TLS") == envValueTrue {
+		scheme = "http"
+	}
+
+	return scheme + "://" + parsed.Host
 }
 
 // isNtfyServerAvailable checks if the ntfy server is reachable.

--- a/testing/e2e/ntfy/suite_test.go
+++ b/testing/e2e/ntfy/suite_test.go
@@ -1,0 +1,164 @@
+package e2e_test
+
+import (
+	"bufio"
+	"context"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+// envValueTrue is the string value for boolean true in environment variables.
+const envValueTrue = "true"
+
+// Test_Ntfy_E2E runs the ntfy E2E test suite using Ginkgo.
+// These tests connect to a real ntfy server and verify actual behavior.
+//
+// Environment variables:
+//   - SHOUTRRR_NTFY_URL: ntfy server URL (default: ntfy://localhost:8080/shoutrrr-e2e-test)
+//   - SHOUTRRR_NTFY_USERNAME: Basic auth username (optional)
+//   - SHOUTRRR_NTFY_PASSWORD: Basic auth password (optional)
+//   - SHOUTRRR_NTFY_DISABLE_TLS: Set to "true" to use HTTP instead of HTTPS (optional)
+func Test_Ntfy_E2E(t *testing.T) { //nolint:paralleltest // mutates process-wide env via loadEnvFile
+	loadEnvFile(".env")
+
+	gomega.RegisterFailHandler(ginkgo.Fail)
+
+	// Add delay between tests to respect ntfy rate limits
+	ginkgo.BeforeEach(func() {
+		time.Sleep(500 * time.Millisecond)
+	})
+
+	ginkgo.RunSpecs(t, "ntfy E2E Tests")
+}
+
+// buildServiceURL constructs the ntfy service URL from environment variables.
+func buildServiceURL() string {
+	baseURL := os.Getenv("SHOUTRRR_NTFY_URL")
+	if baseURL == "" {
+		baseURL = "ntfy://localhost:8080/shoutrrr-e2e-test"
+	}
+
+	serviceURL, err := url.Parse(baseURL)
+	if err != nil {
+		return baseURL
+	}
+
+	query := serviceURL.Query()
+	if os.Getenv("SHOUTRRR_NTFY_DISABLE_TLS") == envValueTrue {
+		query.Set("disabletls", "yes")
+	}
+
+	username := os.Getenv("SHOUTRRR_NTFY_USERNAME")
+	password := os.Getenv("SHOUTRRR_NTFY_PASSWORD")
+
+	if username != "" || password != "" {
+		if password != "" {
+			serviceURL.User = url.UserPassword(username, password)
+		} else {
+			serviceURL.User = url.User(username)
+		}
+	}
+
+	serviceURL.RawQuery = query.Encode()
+
+	result := serviceURL.String()
+	if !strings.Contains(result, "?") {
+		result += "?"
+	}
+
+	return result
+}
+
+// addQueryParam adds a query parameter to a URL string.
+func addQueryParam(rawURL, key, value string) string {
+	serviceURL, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+
+	query := serviceURL.Query()
+	query.Set(key, value)
+	serviceURL.RawQuery = query.Encode()
+
+	return serviceURL.String()
+}
+
+// loadEnvFile loads environment variables from a .env file.
+func loadEnvFile(filename string) {
+	file, err := os.Open(filename)
+	if err != nil {
+		// .env file doesn't exist, skip loading
+		return
+	}
+
+	defer func() { _ = file.Close() }()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) == 2 {
+			key := strings.TrimSpace(parts[0])
+			value := strings.TrimSpace(parts[1])
+			// Remove quotes if present
+			value = strings.Trim(value, `"'`)
+			if _, exists := os.LookupEnv(key); !exists {
+				_ = os.Setenv(key, value)
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return
+	}
+}
+
+// getNtfyBaseURL returns the base URL for the ntfy server using shared host and scheme logic.
+func getNtfyBaseURL() string {
+	host := os.Getenv("SHOUTRRR_NTFY_HOST")
+	if host == "" {
+		host = "localhost:8080"
+	}
+
+	scheme := "http"
+	if os.Getenv("SHOUTRRR_NTFY_DISABLE_TLS") != envValueTrue {
+		scheme = "https"
+	}
+
+	return scheme + "://" + host
+}
+
+// isNtfyServerAvailable checks if the ntfy server is reachable.
+func isNtfyServerAvailable() bool {
+	baseURL := getNtfyBaseURL()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/v1/health", http.NoBody)
+	if err != nil {
+		return false
+	}
+
+	client := &http.Client{Timeout: 2 * time.Second}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return false
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	return resp.StatusCode == http.StatusOK
+}

--- a/testing/e2e/ntfy/tls_test.go
+++ b/testing/e2e/ntfy/tls_test.go
@@ -1,0 +1,76 @@
+package e2e_test
+
+import (
+	"net/url"
+	"os"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	"github.com/nicholas-fedor/shoutrrr/internal/testutils"
+	"github.com/nicholas-fedor/shoutrrr/pkg/services/push/ntfy"
+)
+
+var _ = ginkgo.Describe("ntfy E2E TLS Tests", func() {
+	ginkgo.When("running e2e tests against a real ntfy server", func() {
+		ginkgo.BeforeEach(func() {
+			if !isNtfyServerAvailable() {
+				ginkgo.Skip("ntfy server not available, skipping e2e tests")
+			}
+		})
+
+		ginkgo.It("should send a message over HTTP when DisableTLS is set", func() {
+			serviceURLStr := buildServiceURL()
+			serviceURL, err := url.Parse(serviceURLStr)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			service := &ntfy.Service{}
+			err = service.Initialize(serviceURL, testutils.TestLogger())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			gomega.Expect(service.Config.DisableTLS).To(gomega.BeTrue())
+			gomega.Expect(service.Config.Scheme).To(gomega.Equal("http"))
+
+			topic := service.Config.Topic
+			message := "E2E Test: HTTP message"
+
+			err = service.Send(message, nil)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			verifyMessageReceived(topic, message)
+		})
+
+		ginkgo.It("should send a message over HTTPS by default", func() {
+			disableTLS := os.Getenv("SHOUTRRR_NTFY_DISABLE_TLS")
+			if disableTLS == "true" {
+				ginkgo.Skip("HTTPS test skipped because DisableTLS is set")
+			}
+
+			serviceURLStr := buildServiceURL()
+			serviceURL, err := url.Parse(serviceURLStr)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			service := &ntfy.Service{}
+			err = service.Initialize(serviceURL, testutils.TestLogger())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			gomega.Expect(service.Config.DisableTLS).To(gomega.BeFalse())
+			gomega.Expect(service.Config.Scheme).To(gomega.Equal("https"))
+
+			topic := service.Config.Topic
+			message := "E2E Test: HTTPS message"
+
+			err = service.Send(message, nil)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			verifyMessageReceived(topic, message)
+		})
+	})
+
+	ginkgo.When("no server is configured", func() {
+		ginkgo.It("should return the correct service ID", func() {
+			service := &ntfy.Service{}
+			gomega.Expect(service.GetID()).To(gomega.Equal("ntfy"))
+		})
+	})
+})

--- a/testing/e2e/ntfy/tls_test.go
+++ b/testing/e2e/ntfy/tls_test.go
@@ -20,6 +20,11 @@ var _ = ginkgo.Describe("ntfy E2E TLS Tests", func() {
 		})
 
 		ginkgo.It("should send a message over HTTP when DisableTLS is set", func() {
+			disableTLS := os.Getenv("SHOUTRRR_NTFY_DISABLE_TLS")
+			if disableTLS != "true" {
+				ginkgo.Skip("HTTP test skipped because DisableTLS is not set")
+			}
+
 			serviceURLStr := buildServiceURL()
 			serviceURL, err := url.Parse(serviceURLStr)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/testing/integration/ntfy/README.md
+++ b/testing/integration/ntfy/README.md
@@ -1,0 +1,83 @@
+# Ntfy Integration Tests
+
+This directory contains integration tests for the Ntfy push notification service in Shoutrrr.
+The tests validate ntfy functionality by mocking HTTP requests to the ntfy API, ensuring feature parity with the ntfy.sh service.
+
+## Test Coverage
+
+### Configuration Options
+
+- URL parsing for `ntfy://` scheme
+- Topic path handling (simple and nested paths)
+- Username/password authentication from URL
+- Query parameters (priority, tags, markdown, cache, firebase, title, click, attach, actions, delay, email, icon, filename)
+- Default values (https scheme, ntfy.sh host, default priority)
+- DisableTLS option (forces HTTP scheme)
+- DisableTLSVerification option
+
+### Message Sending
+
+- Basic message sending
+- Empty message handling
+- Title via URL query parameter
+- Title via params map
+- Priority configuration
+- Tags configuration
+- Markdown formatting
+- Click action links
+- Attachment URLs
+- Action buttons
+- Delayed delivery
+- Email notifications
+- Icon URLs
+- Filename for attachments
+- Unicode message support
+- Basic authentication
+
+### Error Handling
+
+- HTTP error responses (400, 401, 403, 404, 500)
+- Network errors (connection refused, timeout)
+- Malformed API error responses
+- Empty error body handling
+
+## Running the Tests
+
+### Mocked Integration Tests (Default)
+
+Run all integration tests with mocked ntfy API responses:
+
+```bash
+go test ./testing/integration/ntfy/ -v
+```
+
+Or run specific test categories:
+
+```bash
+# Run specific test categories
+go test ./testing/integration/ntfy/ -run TestServiceInitialization -v
+go test ./testing/integration/ntfy/ -run TestSend -v
+go test ./testing/integration/ntfy/ -run 'TestSendWith.*Error|TestSendWith(400|401|403|404|500)|TestSendWithTimeout|TestSendWith(Nil|Empty)Params' -v
+```
+
+## Test Structure
+
+The test suite is organized as a flat directory structure with individual test files for each feature category:
+
+```bash
+testing/integration/ntfy/
+├── utils_test.go        # Helper functions and mock implementations
+├── config_test.go       # Configuration and URL parsing tests
+├── send_test.go         # Message sending tests
+├── errors_test.go       # Error handling tests
+└── README.md            # This documentation
+```
+
+### Test Organization
+
+Each test file contains independent black-box tests for specific ntfy service behaviors.
+Tests validate that the service correctly interacts with external APIs without inspecting internal data structures:
+
+- **Config Tests** (`config_test.go`): Service configuration application in external API requests
+- **Send Tests** (`send_test.go`): Service handling of various message types and external API responses
+- **Error Tests** (`errors_test.go`): Service error handling when external APIs return failures

--- a/testing/integration/ntfy/README.md
+++ b/testing/integration/ntfy/README.md
@@ -66,11 +66,12 @@ The test suite is organized as a flat directory structure with individual test f
 
 ```bash
 testing/integration/ntfy/
-├── utils_test.go        # Helper functions and mock implementations
-├── config_test.go       # Configuration and URL parsing tests
-├── send_test.go         # Message sending tests
-├── errors_test.go       # Error handling tests
-└── README.md            # This documentation
+├── utils_test.go           # Helper functions and mock implementations
+├── config_test.go          # Configuration and URL parsing tests
+├── send_test.go            # Message sending tests
+├── errors_test.go          # Error handling tests
+├── api_compliance_test.go  # API compliance tests
+└── README.md               # This documentation
 ```
 
 ### Test Organization
@@ -81,3 +82,4 @@ Tests validate that the service correctly interacts with external APIs without i
 - **Config Tests** (`config_test.go`): Service configuration application in external API requests
 - **Send Tests** (`send_test.go`): Service handling of various message types and external API responses
 - **Error Tests** (`errors_test.go`): Service error handling when external APIs return failures
+- **API Compliance Tests** (`api_compliance_test.go`): URL format, HTTP method, Content-Type including Markdown, User-Agent, and Basic Auth behavior

--- a/testing/integration/ntfy/api_compliance_test.go
+++ b/testing/integration/ntfy/api_compliance_test.go
@@ -1,0 +1,220 @@
+package ntfy_test
+
+import (
+	"encoding/base64"
+	"net/http"
+	"testing"
+	"testing/synctest"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/nicholas-fedor/shoutrrr/internal/meta"
+)
+
+func TestAPIURLFormat(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			"ntfy://ntfy.example.com/mytopic",
+		)
+
+		err := service.Send("test", nil)
+		require.NoError(t, err)
+
+		assertRequestMade(t, mockClient, "https://ntfy.example.com/mytopic")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestAPIURLFormatWithNestedTopic(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			"ntfy://ntfy.example.com/alerts/critical",
+		)
+
+		err := service.Send("test", nil)
+		require.NoError(t, err)
+
+		assertRequestMade(t, mockClient, "https://ntfy.example.com/alerts/critical")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestHTTPMethodIsPost(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			validNtfyURL,
+		)
+
+		err := service.Send("test", nil)
+		require.NoError(t, err)
+
+		assertRequestMatches(t, mockClient, func(req *http.Request) bool {
+			return req.Method == http.MethodPost
+		}, "POST method")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestContentTypeHeader(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			validNtfyURL,
+		)
+
+		err := service.Send("test", nil)
+		require.NoError(t, err)
+
+		assertRequestHeaderContains(t, mockClient, "Content-Type", "text/plain; charset=utf-8")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestContentTypeHeaderMarkdown(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			validNtfyURL+"?markdown=yes",
+		)
+
+		err := service.Send("test", nil)
+		require.NoError(t, err)
+
+		assertRequestHeaderContains(t, mockClient, "Content-Type", "text/markdown")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestUserAgentHeader(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			validNtfyURL,
+		)
+
+		err := service.Send("test", nil)
+		require.NoError(t, err)
+
+		assertRequestMatches(t, mockClient, func(req *http.Request) bool {
+			userAgent := req.Header.Get("User-Agent")
+
+			return userAgent == "shoutrrr/"+meta.Version
+		}, "User-Agent header")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestBasicAuthHeader(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			"ntfy://myuser:mypass@ntfy.example.com/mytopic",
+		)
+
+		err := service.Send("test", nil)
+		require.NoError(t, err)
+
+		assertRequestMatches(t, mockClient, func(req *http.Request) bool {
+			authHeader := req.Header.Get("Authorization")
+			expected := "Basic " + base64.StdEncoding.EncodeToString([]byte("myuser:mypass"))
+
+			return authHeader == expected
+		}, "Basic Auth header")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestBasicAuthHeaderUsernameOnly(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			"ntfy://myuser@ntfy.example.com/mytopic",
+		)
+
+		err := service.Send("test", nil)
+		require.NoError(t, err)
+
+		assertRequestMatches(t, mockClient, func(req *http.Request) bool {
+			authHeader := req.Header.Get("Authorization")
+			expected := "Basic " + base64.StdEncoding.EncodeToString([]byte("myuser:"))
+
+			return authHeader == expected
+		}, "Basic Auth header with username only")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestDisableTLSUsesHTTP(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			"ntfy://ntfy.example.com/mytopic?disabletls=yes",
+		)
+
+		err := service.Send("test", nil)
+		require.NoError(t, err)
+
+		assertRequestMade(t, mockClient, "http://ntfy.example.com/mytopic")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestRequestBodyIsPlainText(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			validNtfyURL,
+		)
+
+		err := service.Send("plain text body", nil)
+		require.NoError(t, err)
+
+		assertRequestMatches(t, mockClient, func(req *http.Request) bool {
+			contentType := req.Header.Get("Content-Type")
+
+			return contentType == "text/plain; charset=utf-8"
+		}, "plain text Content-Type")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestRequestBodyContainsExactMessage(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			validNtfyURL,
+		)
+
+		message := "Exact message body"
+		err := service.Send(message, nil)
+		require.NoError(t, err)
+
+		assertRequestContains(t, mockClient, message)
+
+		mockClient.AssertExpectations(t)
+	})
+}

--- a/testing/integration/ntfy/config_test.go
+++ b/testing/integration/ntfy/config_test.go
@@ -1,0 +1,268 @@
+package ntfy_test
+
+import (
+	"net/url"
+	"testing"
+	"testing/synctest"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/nicholas-fedor/shoutrrr/pkg/services/push/ntfy"
+)
+
+const validNtfyURL = "ntfy://ntfy.example.com/mytopic"
+
+func TestServiceInitialization(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		service := createTestService(
+			t,
+			validNtfyURL,
+			mockClient,
+		)
+
+		require.NotNil(t, service)
+		require.Equal(t, "ntfy", service.GetID())
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestServiceInitializationWithCredentials(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		serviceURL := "ntfy://user:pass@ntfy.example.com/mytopic"
+		service := createTestService(
+			t,
+			serviceURL,
+			mockClient,
+		)
+
+		require.NotNil(t, service)
+		require.Equal(t, "ntfy", service.GetID())
+		require.Equal(t, "user", service.Config.Username)
+		require.Equal(t, "pass", service.Config.Password)
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestServiceInitializationWithTopicPath(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		serviceURL := "ntfy://ntfy.example.com/alerts/critical"
+		service := createTestService(
+			t,
+			serviceURL,
+			mockClient,
+		)
+
+		require.NotNil(t, service)
+		require.Equal(t, "alerts/critical", service.Config.Topic)
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestServiceInitializationWithDisableTLS(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		serviceURL := "ntfy://ntfy.example.com/mytopic?disabletls=yes"
+		service := createTestService(
+			t,
+			serviceURL,
+			mockClient,
+		)
+
+		require.NotNil(t, service)
+		require.Equal(t, "http", service.Config.Scheme)
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestServiceInitializationWithDisableTLSVerification(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		serviceURL := "ntfy://ntfy.example.com/mytopic?disabletlsverification=yes"
+		service := createTestService(
+			t,
+			serviceURL,
+			mockClient,
+		)
+
+		require.NotNil(t, service)
+		require.True(t, service.Config.DisableTLSVerification)
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestServiceInitializationWithPriority(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		serviceURL := "ntfy://ntfy.example.com/mytopic?priority=Max"
+		service := createTestService(
+			t,
+			serviceURL,
+			mockClient,
+		)
+
+		require.NotNil(t, service)
+		require.Equal(t, ntfy.PriorityMax, service.Config.Priority)
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestServiceInitializationWithMarkdown(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		serviceURL := "ntfy://ntfy.example.com/mytopic?markdown=yes"
+		service := createTestService(
+			t,
+			serviceURL,
+			mockClient,
+		)
+
+		require.NotNil(t, service)
+		require.True(t, service.Config.Markdown)
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestServiceInitializationWithTags(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		serviceURL := "ntfy://ntfy.example.com/mytopic?tags=warning,skull"
+		service := createTestService(
+			t,
+			serviceURL,
+			mockClient,
+		)
+
+		require.NotNil(t, service)
+		require.Equal(t, []string{"warning", "skull"}, service.Config.Tags)
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestServiceInitializationWithTitle(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		serviceURL := "ntfy://ntfy.example.com/mytopic?title=Alert"
+		service := createTestService(
+			t,
+			serviceURL,
+			mockClient,
+		)
+
+		require.NotNil(t, service)
+		require.Equal(t, "Alert", service.Config.Title)
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestServiceInitializationMissingTopic(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service := &ntfy.Service{}
+		serviceURL := mustParseURL(t, "ntfy://ntfy.example.com/")
+
+		err := service.Initialize(serviceURL, &mockLogger{})
+		require.Error(t, err)
+		require.ErrorIs(t, err, ntfy.ErrTopicRequired)
+	})
+}
+
+func TestServiceInitializationWithUsernameOnly(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		serviceURL := "ntfy://myuser@ntfy.example.com/mytopic"
+		service := createTestService(
+			t,
+			serviceURL,
+			mockClient,
+		)
+
+		require.NotNil(t, service)
+		require.Equal(t, "myuser", service.Config.Username)
+		require.Empty(t, service.Config.Password)
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestConfigDefaults(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service := &ntfy.Service{}
+
+		parsedURL, err := url.Parse("ntfy://ntfy.example.com/mytopic")
+		require.NoError(t, err)
+
+		err = service.Initialize(parsedURL, &mockLogger{})
+		require.NoError(t, err)
+
+		require.Equal(t, "https", service.Config.Scheme)
+		require.Equal(t, "ntfy.example.com", service.Config.Host)
+		require.Equal(t, "mytopic", service.Config.Topic)
+		require.Empty(t, service.Config.Username)
+		require.Empty(t, service.Config.Password)
+		require.Empty(t, service.Config.Title)
+		require.Equal(t, "Default", service.Config.Priority.String())
+		require.False(t, service.Config.Markdown)
+		require.True(t, service.Config.Cache)
+		require.True(t, service.Config.Firebase)
+		require.False(t, service.Config.DisableTLSVerification)
+		require.False(t, service.Config.DisableTLS)
+	})
+}
+
+func TestConfigURLRoundTrip(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		service := createTestService(
+			t,
+			"ntfy://user:pass@ntfy.example.com/mytopic?priority=High&tags=warning,skull&markdown=yes",
+			mockClient,
+		)
+
+		require.NotNil(t, service)
+
+		reconstructed := service.Config.GetURL()
+		require.Equal(t, "user", reconstructed.User.Username())
+		password, _ := reconstructed.User.Password()
+		require.Equal(t, "pass", password)
+		require.Equal(t, "ntfy.example.com", reconstructed.Host)
+		require.Equal(t, "/mytopic", reconstructed.Path)
+		require.Equal(t, "High", reconstructed.Query().Get("priority"))
+		require.Equal(t, "warning,skull", reconstructed.Query().Get("tags"))
+		require.Equal(t, "Yes", reconstructed.Query().Get("markdown"))
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+
+	parsed, err := url.Parse(raw)
+	require.NoError(t, err)
+
+	return parsed
+}

--- a/testing/integration/ntfy/errors_test.go
+++ b/testing/integration/ntfy/errors_test.go
@@ -1,0 +1,277 @@
+package ntfy_test
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"testing/synctest"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSendWithHTTPError(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		service := createTestService(
+			t,
+			validNtfyURL,
+			mockClient,
+		)
+
+		mockClient.On("Do", mock.Anything).
+			Return(nil, errors.New("connection refused")).
+			Once()
+
+		err := service.Send("Test message", nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "posting to ntfy API")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWith400BadRequest(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		service := createTestService(
+			t,
+			validNtfyURL,
+			mockClient,
+		)
+
+		mockClient.On("Do", mock.Anything).
+			Return(createMockResponse(http.StatusBadRequest, `{"code":400,"error":"invalid request","link":"https://docs.ntfy.sh"}`), nil).
+			Once()
+
+		err := service.Send("Test message", nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid request")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWith401Unauthorized(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		service := createTestService(
+			t,
+			validNtfyURL,
+			mockClient,
+		)
+
+		mockClient.On("Do", mock.Anything).
+			Return(createMockResponse(http.StatusUnauthorized, `{"code":401,"error":"unauthorized"}`), nil).
+			Once()
+
+		err := service.Send("Test message", nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unauthorized")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWith403Forbidden(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		service := createTestService(
+			t,
+			validNtfyURL,
+			mockClient,
+		)
+
+		mockClient.On("Do", mock.Anything).
+			Return(createMockResponse(http.StatusForbidden, `{"code":403,"error":"forbidden"}`), nil).
+			Once()
+
+		err := service.Send("Test message", nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "forbidden")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWith404NotFound(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		service := createTestService(
+			t,
+			validNtfyURL,
+			mockClient,
+		)
+
+		mockClient.On("Do", mock.Anything).
+			Return(createMockResponse(http.StatusNotFound, `{"code":404,"error":"not found"}`), nil).
+			Once()
+
+		err := service.Send("Test message", nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not found")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWith500ServerError(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		service := createTestService(
+			t,
+			validNtfyURL,
+			mockClient,
+		)
+
+		mockClient.On("Do", mock.Anything).
+			Return(createMockResponse(http.StatusInternalServerError, `{"code":500,"error":"internal server error"}`), nil).
+			Once()
+
+		err := service.Send("Test message", nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "internal server error")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithMalformedAPIErrorResponse(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		service := createTestService(
+			t,
+			validNtfyURL,
+			mockClient,
+		)
+
+		mockClient.On("Do", mock.Anything).
+			Return(createMockResponse(http.StatusBadRequest, `not json`), nil).
+			Once()
+
+		err := service.Send("Test message", nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "posting to ntfy API")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithEmptyErrorBody(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		service := createTestService(
+			t,
+			validNtfyURL,
+			mockClient,
+		)
+
+		mockClient.On("Do", mock.Anything).
+			Return(createMockResponse(http.StatusInternalServerError, ``), nil).
+			Once()
+
+		err := service.Send("Test message", nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "posting to ntfy API")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithTimeout(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		service := createTestService(
+			t,
+			validNtfyURL,
+			mockClient,
+		)
+
+		mockClient.On("Do", mock.Anything).
+			Return(nil, errors.New("deadline exceeded")).
+			Once()
+
+		err := service.Send("Test message", nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "posting to ntfy API")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithNilParams(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		service := createTestService(
+			t,
+			validNtfyURL,
+			mockClient,
+		)
+
+		mockClient.On("Do", mock.Anything).
+			Return(createMockResponse(http.StatusOK, `{"code":200,"error":"OK"}`), nil).
+			Once()
+
+		err := service.Send("Message with nil params", nil)
+		require.NoError(t, err)
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithEmptyParams(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		service := createTestService(
+			t,
+			validNtfyURL,
+			mockClient,
+		)
+
+		mockClient.On("Do", mock.Anything).
+			Return(createMockResponse(http.StatusOK, `{"code":200,"error":"OK"}`), nil).
+			Once()
+
+		params := createTestParams()
+		err := service.Send("Message with empty params", params)
+		require.NoError(t, err)
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithStructuredAPIError(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockClient := &MockHTTPClient{}
+		service := createTestService(
+			t,
+			validNtfyURL,
+			mockClient,
+		)
+
+		mockClient.On("Do", mock.Anything).
+			Return(createMockResponse(http.StatusBadRequest, `{"code":400,"error":"invalid request","link":"https://docs.ntfy.sh"}`), nil).
+			Once()
+
+		err := service.Send("Test message", nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "server response")
+		require.Contains(t, err.Error(), "invalid request")
+		require.Contains(t, err.Error(), "400")
+		require.Contains(t, err.Error(), "https://docs.ntfy.sh")
+
+		mockClient.AssertExpectations(t)
+	})
+}

--- a/testing/integration/ntfy/send_test.go
+++ b/testing/integration/ntfy/send_test.go
@@ -1,0 +1,461 @@
+package ntfy_test
+
+import (
+	"strings"
+	"testing"
+	"testing/synctest"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSendBasicMessage(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			validNtfyURL,
+		)
+
+		err := service.Send("Hello from ntfy integration test", nil)
+		require.NoError(t, err)
+
+		assertRequestContains(t, mockClient, "Hello from ntfy integration test")
+		assertRequestMade(t, mockClient, service.Config.GetAPIURL())
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendEmptyMessage(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			validNtfyURL,
+		)
+
+		err := service.Send("", nil)
+		require.NoError(t, err)
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithTitle(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			validNtfyURL,
+		)
+
+		params := createTestParams("title", "Alert")
+		err := service.Send("Something happened", params)
+
+		require.NoError(t, err)
+		assertRequestHeaderContains(t, mockClient, "Title", "Alert")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithPriority(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			validNtfyURL,
+		)
+
+		params := createTestParams("priority", "High")
+		err := service.Send("Important message", params)
+
+		require.NoError(t, err)
+		assertRequestHeaderContains(t, mockClient, "Priority", "High")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithTags(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			validNtfyURL,
+		)
+
+		params := createTestParams("tags", "warning,skull")
+		err := service.Send("Tagged message", params)
+
+		require.NoError(t, err)
+		assertRequestHeaderContains(t, mockClient, "Tags", "warning,skull")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithMarkdown(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			validNtfyURL+"?markdown=yes",
+		)
+
+		err := service.Send("**bold** text", nil)
+		require.NoError(t, err)
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithClick(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			validNtfyURL,
+		)
+
+		params := createTestParams("click", "https://example.com")
+		err := service.Send("Click me", params)
+
+		require.NoError(t, err)
+		assertRequestHeaderContains(t, mockClient, "Click", "https://example.com")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithAttach(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			validNtfyURL,
+		)
+
+		params := createTestParams("attach", "https://example.com/image.png")
+		err := service.Send("Check this out", params)
+
+		require.NoError(t, err)
+		assertRequestHeaderContains(t, mockClient, "Attach", "https://example.com/image.png")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithActions(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			validNtfyURL,
+		)
+
+		params := createTestParams("actions", "view;open")
+		err := service.Send("Action message", params)
+
+		require.NoError(t, err)
+		assertRequestHeaderContains(t, mockClient, "Actions", "view;open")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithDelay(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			validNtfyURL,
+		)
+
+		params := createTestParams("delay", "2h")
+		err := service.Send("Delayed message", params)
+
+		require.NoError(t, err)
+		assertRequestHeaderContains(t, mockClient, "Delay", "2h")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithEmail(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			validNtfyURL,
+		)
+
+		params := createTestParams("email", "user@example.com")
+		err := service.Send("Email notification", params)
+
+		require.NoError(t, err)
+		assertRequestHeaderContains(t, mockClient, "Email", "user@example.com")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithCacheDisabled(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			validNtfyURL+"?cache=no",
+		)
+
+		err := service.Send("No cache", nil)
+		require.NoError(t, err)
+		assertRequestHeaderContains(t, mockClient, "Cache", "no")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithFirebaseDisabled(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			validNtfyURL+"?firebase=no",
+		)
+
+		err := service.Send("No firebase", nil)
+		require.NoError(t, err)
+		assertRequestHeaderContains(t, mockClient, "Firebase", "no")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithBasicAuth(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			"ntfy://user:pass@ntfy.example.com/mytopic",
+		)
+
+		err := service.Send("Authenticated message", nil)
+		require.NoError(t, err)
+		assertRequestHeaderContains(t, mockClient, "Authorization", "Basic ")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithUnicodeMessage(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			validNtfyURL,
+		)
+
+		message := "Hello 世界 🌍"
+		err := service.Send(message, nil)
+		require.NoError(t, err)
+
+		assertRequestContains(t, mockClient, message)
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithIcon(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			validNtfyURL,
+		)
+
+		params := createTestParams("icon", "https://example.com/icon.png")
+		err := service.Send("With icon", params)
+
+		require.NoError(t, err)
+		assertRequestHeaderContains(t, mockClient, "X-Icon", "https://example.com/icon.png")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithFilename(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			validNtfyURL,
+		)
+
+		params := createTestParams("filename", "report.pdf")
+		err := service.Send("Here is the report", params)
+
+		require.NoError(t, err)
+		assertRequestHeaderContains(t, mockClient, "Filename", "report.pdf")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithMultipleTags(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			validNtfyURL,
+		)
+
+		params := createTestParams("tags", "warning,skull,fire")
+		err := service.Send("Tagged message", params)
+
+		require.NoError(t, err)
+		assertRequestHeaderContains(t, mockClient, "Tags", "warning,skull,fire")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithMultipleActions(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			validNtfyURL,
+		)
+
+		params := createTestParams("actions", "view;open;reply")
+		err := service.Send("Action message", params)
+
+		require.NoError(t, err)
+		assertRequestHeaderContains(t, mockClient, "Actions", "view;open;reply")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithCombinedParams(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			validNtfyURL,
+		)
+
+		params := createTestParams(
+			"title", "Combined",
+			"priority", "High",
+			"tags", "warning,skull",
+		)
+		err := service.Send("Combined message", params)
+
+		require.NoError(t, err)
+		assertRequestHeaderContains(t, mockClient, "Title", "Combined")
+		assertRequestHeaderContains(t, mockClient, "Priority", "High")
+		assertRequestHeaderContains(t, mockClient, "Tags", "warning,skull")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithTitleViaURL(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			validNtfyURL+"?title=URLTitle",
+		)
+
+		err := service.Send("Message body", nil)
+		require.NoError(t, err)
+		assertRequestHeaderContains(t, mockClient, "Title", "URLTitle")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithPriorityViaURL(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			validNtfyURL+"?priority=Max",
+		)
+
+		err := service.Send("Important", nil)
+		require.NoError(t, err)
+		assertRequestHeaderContains(t, mockClient, "Priority", "Max")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithSpecialCharacters(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			validNtfyURL,
+		)
+
+		message := "Special: <>@#$%^&*()"
+		err := service.Send(message, nil)
+		require.NoError(t, err)
+
+		assertRequestContains(t, mockClient, message)
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithNewlines(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			validNtfyURL,
+		)
+
+		err := service.Send("Line 1\nLine 2\nLine 3", nil)
+		require.NoError(t, err)
+		assertRequestContains(t, mockClient, "Line 1\nLine 2\nLine 3")
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithLongMessage(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			validNtfyURL,
+		)
+
+		longMessage := strings.Repeat("a", 10000)
+		err := service.Send(longMessage, nil)
+		require.NoError(t, err)
+		assertRequestContains(t, mockClient, longMessage)
+
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestSendWithDisableTLSVerification(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		service, mockClient := createTestServiceWithMock(
+			t,
+			"ntfy://ntfy.example.com/mytopic?disabletlsverification=yes",
+		)
+
+		err := service.Send("test", nil)
+		require.NoError(t, err)
+
+		mockClient.AssertExpectations(t)
+	})
+}

--- a/testing/integration/ntfy/utils_test.go
+++ b/testing/integration/ntfy/utils_test.go
@@ -1,0 +1,213 @@
+package ntfy_test
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+
+	"github.com/nicholas-fedor/shoutrrr/pkg/services/push/ntfy"
+	"github.com/nicholas-fedor/shoutrrr/pkg/types"
+)
+
+// MockHTTPClient is a testify mock that implements the types.HTTPClient interface.
+type MockHTTPClient struct {
+	mock.Mock
+}
+
+// mockLogger is a simple logger implementation for testing.
+type mockLogger struct{}
+
+func (m *mockLogger) Print(_ ...any)            {}
+func (m *mockLogger) Printf(_ string, _ ...any) {}
+func (m *mockLogger) Println(_ ...any)          {}
+
+// createTestService creates an ntfy service instance configured for testing.
+func createTestService(
+	t *testing.T,
+	serviceURL string,
+	httpClients ...types.HTTPClient,
+) *ntfy.Service {
+	t.Helper()
+
+	service := &ntfy.Service{}
+
+	parsedURL, err := url.Parse(serviceURL)
+	if err != nil {
+		t.Fatalf("failed to parse service URL: %v", err)
+	}
+
+	err = service.Initialize(parsedURL, &mockLogger{})
+	if err != nil {
+		t.Fatalf("failed to initialize service: %v", err)
+	}
+
+	// Override the HTTPClient if provided (after Initialize sets the default)
+	if len(httpClients) > 0 && httpClients[0] != nil {
+		service.SetHTTPClient(httpClients[0])
+	}
+
+	return service
+}
+
+// createTestParams creates test parameters with the given key-value pairs.
+func createTestParams(pairs ...string) *types.Params {
+	params := make(types.Params)
+
+	for i := 0; i < len(pairs); i += 2 {
+		if i+1 < len(pairs) {
+			params[pairs[i]] = pairs[i+1]
+		}
+	}
+
+	return &params
+}
+
+// createTestServiceWithMock creates an ntfy service instance configured for testing,
+// along with a MockHTTPClient that is already configured on the service and seeded
+// with a default successful 200 OK Do expectation.
+func createTestServiceWithMock(
+	t *testing.T,
+	serviceURL string,
+) (*ntfy.Service, *MockHTTPClient) {
+	t.Helper()
+
+	mockClient := &MockHTTPClient{}
+	service := createTestService(t, serviceURL, mockClient)
+
+	mockClient.On("Do", mock.Anything).
+		Return(createMockResponse(http.StatusOK, `{"code":200,"error":"OK"}`), nil).
+		Once()
+
+	return service, mockClient
+}
+
+func (m *MockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	if req.Body != nil {
+		body, err := io.ReadAll(req.Body)
+		if err == nil {
+			req.Body = io.NopCloser(bytes.NewReader(body))
+		}
+	}
+
+	args := m.Called(req)
+
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(*http.Response), args.Error(1)
+}
+
+// createMockResponse creates a mock HTTP response with the given status code and body.
+func createMockResponse(statusCode int, body string) *http.Response {
+	resp := &http.Response{
+		StatusCode: statusCode,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+
+	return resp
+}
+
+// findMatchingRequest iterates over mock Do calls and returns the first request
+// that matches the given predicate, or nil if no match is found.
+func findMatchingRequest(
+	mockClient *MockHTTPClient,
+	predicate func(*http.Request) bool,
+) *http.Request {
+	for i := range mockClient.Calls {
+		call := &mockClient.Calls[i]
+		if call.Method == "Do" {
+			req := call.Arguments[0].(*http.Request)
+			if predicate(req) {
+				return req
+			}
+		}
+	}
+
+	return nil
+}
+
+// assertRequestContains asserts that the HTTP request body contains the expected content.
+func assertRequestContains(t *testing.T, mockClient *MockHTTPClient, expectedContent string) {
+	t.Helper()
+
+	req := findMatchingRequest(mockClient, func(req *http.Request) bool {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return false
+		}
+
+		req.Body = io.NopCloser(bytes.NewReader(body))
+
+		return strings.Contains(string(body), expectedContent)
+	})
+
+	if req == nil {
+		t.Errorf("Expected request body to contain %q, but no matching call found", expectedContent)
+	}
+}
+
+// assertRequestHeaderContains asserts that at least one HTTP request contains the expected header value.
+func assertRequestHeaderContains(
+	t *testing.T,
+	mockClient *MockHTTPClient,
+	headerName,
+	expectedValue string,
+) {
+	t.Helper()
+
+	req := findMatchingRequest(mockClient, func(req *http.Request) bool {
+		if values := req.Header.Values(headerName); len(values) > 0 {
+			for _, v := range values {
+				if strings.Contains(v, expectedValue) {
+					return true
+				}
+			}
+		}
+
+		return false
+	})
+
+	if req == nil {
+		t.Errorf("Expected request header %q to contain %q, but no matching call found", headerName, expectedValue)
+	}
+}
+
+// assertRequestMade asserts that an HTTP POST request was made to the expected URL.
+func assertRequestMade(
+	t *testing.T,
+	mockClient *MockHTTPClient,
+	expectedURL string,
+) {
+	t.Helper()
+
+	req := findMatchingRequest(mockClient, func(req *http.Request) bool {
+		return req.Method == http.MethodPost && req.URL.String() == expectedURL
+	})
+
+	if req == nil {
+		t.Errorf("Expected POST request to %s, but no matching call found", expectedURL)
+	}
+}
+
+// assertRequestMatches asserts that at least one HTTP request matches the given predicate.
+func assertRequestMatches(
+	t *testing.T,
+	mockClient *MockHTTPClient,
+	predicate func(*http.Request) bool,
+	description string,
+) {
+	t.Helper()
+
+	req := findMatchingRequest(mockClient, predicate)
+
+	if req == nil {
+		t.Errorf("Expected request to match %s, but no matching call found", description)
+	}
+}


### PR DESCRIPTION
This PR adds markdown formatting support to the ntfy service. In addition, it refactors the ntfy service's testing to include unit, integration, and e2e testing suites.

## Problem

The ntfy service lacked markdown support and its test coverage was limited to basic unit tests without integration or end-to-end validation.

## Solution

The ntfy service now supports markdown formatting through a query parameter that sets the Content-Type header appropriately. 
The old monolithic test file was removed and a new unit testing suite was added. In addition, separate integration and e2e testing suites were added, including scripting for the e2e testing setup.

## Changes

- Added markdown support
- Refactored and expanded testing to include unit, integration, and e2e testing suites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to send Ntfy notifications with Markdown formatting, disabled by default.
  * Markdown notifications now use the appropriate content type.

* **Documentation**
  * Documented the Markdown option and Ntfy testing setup.

* **Tests**
  * Expanded coverage for formatting, authentication, TLS, configuration, message features, errors, and end-to-end delivery.
  * Added local Docker-based testing support for Ntfy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->