### PR TITLE
feat(smtp): added smtp AUTH LOGIN authentication method

### DIFF
--- a/pkg/services/email/smtp/doc.go
+++ b/pkg/services/email/smtp/doc.go
@@ -3,7 +3,7 @@
 // authentication, encryption, and message formatting options.
 //
 // The package supports the following features:
-//   - Authentication methods: None, Plain, CRAM-MD5, and OAuth2.
+//   - Authentication methods: None, Plain, Login, CRAM-MD5, and OAuth2.
 //   - Encryption methods: None, ExplicitTLS (using STARTTLS), ImplicitTLS (TLS for the entire session), and Auto (port-based selection).
 //   - Message formats: Plain text or HTML with multipart/alternative support.
 //   - Configuration via a URL scheme (e.g., `smtp://user:password@host:port/?fromAddress=sender@example.com&toAddresses=recipient@example.com`).
@@ -55,7 +55,7 @@
 //   - FromAddress and FromName: The sender's email address and display name.
 //   - ToAddresses: A list of recipient email addresses.
 //   - Subject: The email subject (defaults to "Shoutrrr Notification").
-//   - Auth: The authentication method (None, Plain, CRAMMD5, OAuth2, or Unknown).
+//   - Auth: The authentication method (None, Plain, Login, CRAMMD5, OAuth2, or Unknown).
 //   - Encryption: The encryption method (None, ExplicitTLS, ImplicitTLS, or Auto).
 //   - UseStartTLS: Whether to use STARTTLS for encryption (default: true).
 //   - UseHTML: Whether to send the message as HTML (default: false).
@@ -82,6 +82,7 @@
 // The package supports multiple authentication methods, defined in [authType] and [AuthTypes]:
 //   - None: No authentication.
 //   - Plain: Username and password-based authentication.
+//   - Login: Username and password-based authentication. Useful if mail servers don't support AUTH PLAIN.
 //   - CRAMMD5: Challenge-response authentication using CRAM-MD5.
 //   - OAuth2: Token-based authentication for services like Gmail (see [OAuth2Auth]).
 //     Note that OAuth2 support is limited to static access tokens and does not

--- a/pkg/services/email/smtp/smtp.go
+++ b/pkg/services/email/smtp/smtp.go
@@ -250,7 +250,7 @@ func (s *Service) getAuth(config *Config) (smtp.Auth, failure) {
 	case AuthTypes.OAuth2:
 		return OAuth2Auth(config.Username, config.Password), nil
 	case AuthTypes.Login:
-		return LoginAuth(config.Username, config.Password), nil
+		return LoginAuth(config.Username, config.Password, config.Host), nil
 	case AuthTypes.Unknown:
 		return nil, fail(FailAuthType, nil, config.Auth.String())
 	default:

--- a/pkg/services/email/smtp/smtp.go
+++ b/pkg/services/email/smtp/smtp.go
@@ -249,6 +249,8 @@ func (s *Service) getAuth(config *Config) (smtp.Auth, failure) {
 		return smtp.CRAMMD5Auth(config.Username, config.Password), nil
 	case AuthTypes.OAuth2:
 		return OAuth2Auth(config.Username, config.Password), nil
+	case AuthTypes.Login:
+		return LoginAuth(config.Username, config.Password), nil
 	case AuthTypes.Unknown:
 		return nil, fail(FailAuthType, nil, config.Auth.String())
 	default:

--- a/pkg/services/email/smtp/smtp_authtype.go
+++ b/pkg/services/email/smtp/smtp_authtype.go
@@ -13,6 +13,7 @@ type authTypeVals struct {
 	CRAMMD5 authType
 	Unknown authType
 	OAuth2  authType
+	Login   authType
 	Enum    types.EnumFormatter
 }
 
@@ -22,6 +23,7 @@ const (
 	AuthCRAMMD5                 // 2
 	AuthUnknown                 // 3
 	AuthOAuth2                  // 4
+	AuthLogin                   // 5
 )
 
 // AuthTypes is the enum helper for populating the Auth field.
@@ -31,6 +33,7 @@ var AuthTypes = &authTypeVals{
 	CRAMMD5: AuthCRAMMD5,
 	Unknown: AuthUnknown,
 	OAuth2:  AuthOAuth2,
+	Login:   AuthLogin,
 	Enum: format.CreateEnumFormatter(
 		[]string{
 			"None",
@@ -38,6 +41,7 @@ var AuthTypes = &authTypeVals{
 			"CRAMMD5",
 			"Unknown",
 			"OAuth2",
+			"Login",
 		}),
 }
 

--- a/pkg/services/email/smtp/smtp_login.go
+++ b/pkg/services/email/smtp/smtp_login.go
@@ -1,36 +1,132 @@
 package smtp
 
 import (
+	"errors"
+	"fmt"
 	"net/smtp"
 )
 
+// loginAuth implements the SASL LOGIN authentication mechanism for SMTP.
+//
+// Challenge prompt text from the server is ignored.
+// The username and password are sent in order as successive client responses.
 type loginAuth struct {
 	username, password string
+	host               string
+	respStep           uint8
 }
 
-// LoginAuth returns an Auth that implements the SASL LOGIN authentication
-func LoginAuth(username, password string) smtp.Auth {
-	return &loginAuth{username, password}
-}
+var (
+	// errUnencryptedConnection is returned when authentication is attempted
+	// on a non-local server without TLS.
+	errUnencryptedConnection = errors.New("unencrypted connection")
 
-func (a *loginAuth) Next(fromServer []byte, more bool) ([]byte, error) {
-	if more {
+	// errWrongHostName is returned when the server name does not match the
+	// expected host.
+	errWrongHostName = errors.New("wrong host name")
 
-		responseString := string(fromServer)
+	// errUnexpectedServerChallenge is returned when the server issues an additional
+	// challenge after the client has finished sending credentials.
+	errUnexpectedServerChallenge = errors.New("unexpected server challenge")
+)
 
-		if responseString == "Username:" {
-			return []byte(a.username), nil
-		}
-
-		if responseString == "Password:" {
-			return []byte(a.password), nil
-		}
-
-		return []byte("failed to perform AUTH LOGIN"), nil
+// LoginAuth returns an [smtp.Auth] that implements SASL LOGIN authentication.
+//
+// LOGIN is a multi-step mechanism commonly offered by servers that do not
+// support AUTH PLAIN:
+//  1. The client sends AUTH LOGIN.
+//  2. The server issues a challenge (often a username prompt) and the client sends the username.
+//  3. The server issues a challenge (often a password prompt) and the client sends the password.
+//
+// Challenge contents are ignored per draft-murchison-sasl-login-00 so that
+// common server variants (different wording, casing, or trailing NULs) work.
+//
+// Credentials are sent only when the connection uses TLS or the server name is
+// localhost. Otherwise authentication fails without transmitting credentials,
+// matching [smtp.PlainAuth].
+//
+// Parameters:
+//   - username: The SMTP account username.
+//   - password: The SMTP account password.
+//   - host: The expected SMTP server hostname, which must match [smtp.ServerInfo.Name] at Start.
+//
+// Returns:
+//   - An [smtp.Auth] that performs LOGIN authentication for the given credentials and host.
+func LoginAuth(username, password, host string) smtp.Auth {
+	return &loginAuth{
+		username: username,
+		password: password,
+		host:     host,
+		respStep: 0,
 	}
-	return nil, nil
 }
 
-func (a *loginAuth) Start(_ *smtp.ServerInfo) (string, []byte, error) {
+// isLocalhost reports whether name is a loopback host identity.
+//
+// Parameters:
+//   - name: The server name to check (for example from [smtp.ServerInfo.Name]).
+//
+// Returns:
+//   - true if name is "localhost", "127.0.0.1", or "::1"; otherwise, false.
+func isLocalhost(name string) bool {
+	return name == "localhost" || name == "127.0.0.1" || name == "::1"
+}
+
+// Next continues the LOGIN challenge-response exchange.
+//
+// When more is true, the next credential is returned by step order (username,
+// then password). Challenge bytes from the server are ignored. An extra
+// challenge after the password step returns an error so net/smtp aborts AUTH
+// instead of sending a dummy client response.
+//
+// Parameters:
+//   - fromServer: The decoded server challenge payload (ignored for LOGIN).
+//   - more: Whether the server expects another client response (SMTP 334).
+//
+// Returns:
+//   - The next client response (username or password bytes), or nil when the exchange is finished.
+//   - A non-nil error if the server issues an unexpected additional challenge.
+func (a *loginAuth) Next(fromServer []byte, more bool) ([]byte, error) {
+	if !more {
+		return nil, nil
+	}
+
+	// Answer by step order; do not parse challenge text.
+	switch a.respStep {
+	case 0:
+		a.respStep++
+
+		return []byte(a.username), nil
+	case 1:
+		a.respStep++
+
+		return []byte(a.password), nil
+	default:
+		return nil, fmt.Errorf("%w: %q", errUnexpectedServerChallenge, fromServer)
+	}
+}
+
+// Start begins LOGIN authentication after validating TLS and host identity.
+//
+// Parameters:
+//   - server: Connection metadata from the SMTP client, including Name and TLS.
+//
+// Returns:
+//   - The authentication protocol name ("LOGIN").
+//   - An empty initial client response (LOGIN has no initial SASL payload).
+//   - A non-nil error if the connection is unencrypted to a non-local host or the host name does not match.
+func (a *loginAuth) Start(server *smtp.ServerInfo) (string, []byte, error) {
+	// Require TLS unless the server name is localhost. Without TLS, ServerInfo
+	// cannot be trusted and an attacker could advertise LOGIN to harvest credentials.
+	if !server.TLS && !isLocalhost(server.Name) {
+		return "", nil, errUnencryptedConnection
+	}
+
+	if server.Name != a.host {
+		return "", nil, errWrongHostName
+	}
+
+	a.respStep = 0
+
 	return "LOGIN", nil, nil
 }

--- a/pkg/services/email/smtp/smtp_login.go
+++ b/pkg/services/email/smtp/smtp_login.go
@@ -1,0 +1,36 @@
+package smtp
+
+import (
+	"net/smtp"
+)
+
+type loginAuth struct {
+	username, password string
+}
+
+// LoginAuth returns an Auth that implements the SASL LOGIN authentication
+func LoginAuth(username, password string) smtp.Auth {
+	return &loginAuth{username, password}
+}
+
+func (a *loginAuth) Next(fromServer []byte, more bool) ([]byte, error) {
+	if more {
+
+		responseString := string(fromServer)
+
+		if responseString == "Username:" {
+			return []byte(a.username), nil
+		}
+
+		if responseString == "Password:" {
+			return []byte(a.password), nil
+		}
+
+		return []byte("failed to perform AUTH LOGIN"), nil
+	}
+	return nil, nil
+}
+
+func (a *loginAuth) Start(_ *smtp.ServerInfo) (string, []byte, error) {
+	return "LOGIN", nil, nil
+}

--- a/pkg/services/email/smtp/smtp_login_test.go
+++ b/pkg/services/email/smtp/smtp_login_test.go
@@ -1,0 +1,161 @@
+package smtp
+
+import (
+	"errors"
+	"net/smtp"
+	"strings"
+	"testing"
+)
+
+func TestLoginAuthStart(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		host    string
+		server  *smtp.ServerInfo
+		wantErr error
+	}{
+		{
+			name:   "TLS and matching host",
+			host:   "mail.example.com",
+			server: &smtp.ServerInfo{Name: "mail.example.com", TLS: true},
+		},
+		{
+			name:   "localhost without TLS",
+			host:   "localhost",
+			server: &smtp.ServerInfo{Name: "localhost", TLS: false},
+		},
+		{
+			name:   "127.0.0.1 without TLS",
+			host:   "127.0.0.1",
+			server: &smtp.ServerInfo{Name: "127.0.0.1", TLS: false},
+		},
+		{
+			name:    "unencrypted remote",
+			host:    "mail.example.com",
+			server:  &smtp.ServerInfo{Name: "mail.example.com", TLS: false},
+			wantErr: errUnencryptedConnection,
+		},
+		{
+			name:    "wrong host",
+			host:    "mail.example.com",
+			server:  &smtp.ServerInfo{Name: "evil.example.com", TLS: true},
+			wantErr: errWrongHostName,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			auth := LoginAuth("user", "pass", tt.host)
+
+			mech, resp, err := auth.Start(tt.server)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Start() error = %v, want %v", err, tt.wantErr)
+			}
+
+			if tt.wantErr != nil {
+				return
+			}
+
+			if mech != "LOGIN" {
+				t.Errorf("Start() mech = %q, want LOGIN", mech)
+			}
+
+			if resp != nil {
+				t.Errorf("Start() resp = %v, want nil", resp)
+			}
+		})
+	}
+}
+
+func TestLoginAuthNext(t *testing.T) {
+	t.Parallel()
+
+	auth := LoginAuth("alice", "s3cret", "mail.example.com").(*loginAuth)
+
+	// Successful two-step exchange. Challenge text is ignored.
+	resp, err := auth.Next([]byte("User Name\x00"), true)
+	if err != nil {
+		t.Fatalf("step 0: unexpected error: %v", err)
+	}
+
+	if string(resp) != "alice" {
+		t.Fatalf("step 0: resp = %q, want alice", resp)
+	}
+
+	resp, err = auth.Next([]byte("password:"), true)
+	if err != nil {
+		t.Fatalf("step 1: unexpected error: %v", err)
+	}
+
+	if string(resp) != "s3cret" {
+		t.Fatalf("step 1: resp = %q, want s3cret", resp)
+	}
+
+	// An extra challenge must abort with a non-nil error, not a dummy response.
+	resp, err = auth.Next([]byte("Username:"), true)
+	if err == nil {
+		t.Fatal("step 2: expected error, got nil")
+	}
+
+	if resp != nil {
+		t.Fatalf("step 2: resp = %v, want nil so net/smtp aborts", resp)
+	}
+
+	if !errors.Is(err, errUnexpectedServerChallenge) {
+		t.Fatalf("step 2: error = %v, want %v", err, errUnexpectedServerChallenge)
+	}
+
+	if got := err.Error(); !strings.Contains(got, "Username:") {
+		t.Fatalf("step 2: error = %q, want challenge quoted in message", got)
+	}
+
+	// more=false ends the exchange cleanly.
+	resp, err = auth.Next(nil, false)
+	if err != nil || resp != nil {
+		t.Fatalf("more=false: resp=%v err=%v, want nil,nil", resp, err)
+	}
+}
+
+func TestLoginAuthNextResetsWithStart(t *testing.T) {
+	t.Parallel()
+
+	auth := LoginAuth("u", "p", "localhost").(*loginAuth)
+	if _, err := auth.Next(nil, true); err != nil {
+		t.Fatalf("first Next: %v", err)
+	}
+
+	if _, _, err := auth.Start(&smtp.ServerInfo{Name: "localhost", TLS: false}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	if auth.respStep != 0 {
+		t.Fatalf("respStep after Start = %d, want 0", auth.respStep)
+	}
+
+	resp, err := auth.Next([]byte("Username:"), true)
+	if err != nil {
+		t.Fatalf("Next after Start: %v", err)
+	}
+
+	if string(resp) != "u" {
+		t.Fatalf("Next after Start: resp = %q, want u", resp)
+	}
+}
+
+func TestIsLocalhost(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"localhost", "127.0.0.1", "::1"} {
+		if !isLocalhost(name) {
+			t.Errorf("isLocalhost(%q) = false, want true", name)
+		}
+	}
+
+	if isLocalhost("example.com") {
+		t.Error("isLocalhost(example.com) = true, want false")
+	}
+}

--- a/pkg/services/email/smtp/smtp_test.go
+++ b/pkg/services/email/smtp/smtp_test.go
@@ -290,6 +290,46 @@ var _ = ginkgo.Describe("the SMTP service", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			})
 		})
+		ginkgo.When("given auth=Login", func() {
+			ginkgo.It("should complete the multi-step AUTH LOGIN dialog", func() {
+				testURL := modifyURL(BaseAuthURL, map[string]string{
+					"auth":    "Login",
+					"useHTML": "no",
+				})
+
+				// Multi-step LOGIN: AUTH LOGIN, then two 334 challenges, then 235.
+				// Challenge payloads are base64 of common prompts. The client ignores them.
+				err := testIntegration(testURL, []string{
+					"250-mx.google.com at your service",
+					"250-SIZE 35651584",
+					"250-AUTH LOGIN PLAIN",
+					"250 8BITMIME",
+					"334 VXNlciBOYW1lAA==", // "User Name\0" — non-exact prompt must still work
+					"334 UGFzc3dvcmQ=",     // "Password"
+					"235 Accepted",
+					"250 Sender OK",
+					"250 Receiver OK",
+					"354 Go ahead",
+					"250 Data OK",
+					"250 Sender OK",
+					"250 Receiver OK",
+					"354 Go ahead",
+					"250 Data OK",
+					"221 OK",
+				}, "", "",
+					"AUTH LOGIN",
+					"dXNlcg==",     // base64("user")
+					"cGFzc3dvcmQ=", // base64("password")
+				)
+				if msg, test := standard.IsTestSetupFailure(err); test {
+					ginkgo.Skip(msg)
+
+					return
+				}
+
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			})
+		})
 		ginkgo.When("given e-mail addresses with pluses in the configuration URL", func() {
 			ginkgo.It("should send notifications without any errors", func() {
 				testURL := BasePlusURL


### PR DESCRIPTION
Added support for the AUTH LOGIN authentication mechanism, as certain smtp servers don't support AUTH PLAIN.
AUTH LOGIN may then serve as fallback for such situations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for SMTP LOGIN authentication.
  * Added username and password-based authentication during SMTP connections.
  * Updated SMTP configuration and authentication documentation to include LOGIN support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->