### PR TITLE
feat(pushover): add end-to-end encryption support

### DIFF
--- a/docs/playground/wasm/generator.go
+++ b/docs/playground/wasm/generator.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/nicholas-fedor/shoutrrr/pkg/format"
 	"github.com/nicholas-fedor/shoutrrr/pkg/router"
+	"github.com/nicholas-fedor/shoutrrr/pkg/services/push/pushover"
 	"github.com/nicholas-fedor/shoutrrr/pkg/types"
 )
 
@@ -178,6 +179,10 @@ func generateURLString(serviceName, configJSON string) string {
 
 	if generatedURL == nil {
 		return fmt.Sprintf(`{"url":%q}`, serviceName+"://")
+	}
+
+	if serviceName == pushover.Scheme {
+		pushover.MaskURL(generatedURL)
 	}
 
 	return fmt.Sprintf(`{"url":%q}`, generatedURL.String())

--- a/docs/playground/wasm/wasm_integration_test.go
+++ b/docs/playground/wasm/wasm_integration_test.go
@@ -359,6 +359,38 @@ func TestGenerateURL(t *testing.T) {
 	}
 }
 
+// TestGenerateURLMasksPushoverSecrets verifies that WASM URL generation redacts
+// the Pushover API token and encryption key before returning the URL.
+func TestGenerateURLMasksPushoverSecrets(t *testing.T) {
+	t.Parallel()
+
+	const (
+		token         = "secret-api-token"
+		encryptionKey = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	)
+
+	result := generateURLString("pushover",
+		`{"Token":"`+token+`","User":"userkey","EncryptionKey":"`+encryptionKey+`"}`)
+
+	var parsed map[string]string
+	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+
+	got := parsed["url"]
+	if strings.Contains(got, token) {
+		t.Errorf("generated URL contains API token: %q", got)
+	}
+
+	if strings.Contains(got, encryptionKey) {
+		t.Errorf("generated URL contains encryption key: %q", got)
+	}
+
+	if !strings.Contains(got, "REDACTED") {
+		t.Errorf("generated URL missing redaction placeholder: %q", got)
+	}
+}
+
 // TestExtractScheme verifies URL scheme extraction.
 func TestExtractScheme(t *testing.T) {
 	t.Parallel()

--- a/docs/services/push/pushover/index.md
+++ b/docs/services/push/pushover/index.md
@@ -29,4 +29,24 @@ _pushover://shoutrrr:__`token`__@__`userKey`__/?devices=__`device`__&title=Custo
 !!! note
     Only supply priority values between -1 and 1, since 2 requires additional parameters that are not supported yet.
 
+## End-to-end encryption
+
+Pushover [end-to-end encryption](https://pushover.net/api#e2ee) encrypts `message` and `title` on the client before they are sent.
+Generate a 256-bit key and configure the same value in the Pushover iOS or Android app:
+
+```bash
+openssl rand -hex 32
+```
+
+Then include it in the service URL:
+
+_pushover://shoutrrr:__`token`__@__`userKey`__/?encryptionkey=__`64-char-hex`___
+
+`key` is accepted as an alias for `encryptionkey`.
+A valid key enables encryption automatically.
+An invalid key fails during URL verification, and encryption errors refuse to send rather than falling back to plaintext.
+
+Encrypted fields are larger than the original text and still count toward Pushover's 1024-character field limit.
+Desktop clients cannot decrypt end-to-end encrypted messages.
+
 Please refer to the [Pushover API documentation](https://pushover.net/api#messages) for more information.

--- a/pkg/services/push/pushover/doc.go
+++ b/pkg/services/push/pushover/doc.go
@@ -25,6 +25,7 @@
 //   - devices: comma-separated list of target device names (optional, sends to all devices if not specified)
 //   - priority: message priority (-2 to 1, default: 0)
 //   - title: notification title (optional, defaults to application name)
+//   - encryptionkey: 64-character hex AES-256 key for end-to-end encryption (optional, alias: key)
 //
 // Priority levels:
 //   - -2: lowest - no sound, no notification, stored for later
@@ -108,6 +109,13 @@
 //	url := "pushover://userkey:apitoken@?title=INCIDENT&priority=1"
 //	err := shoutrrr.Send(url, "Database connection lost - immediate attention required")
 //
+// ## End-to-end encryption
+//
+// Encrypt message and title with a 256-bit key also configured in the Pushover app:
+//
+//	url := "pushover://userkey:apitoken@?encryptionkey=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+//	err := shoutrrr.Send(url, "This message is encrypted")
+//
 // # Error Handling
 //
 // The service returns errors for various failure scenarios. Always check the returned error:
@@ -127,10 +135,11 @@
 //
 // # Security Considerations
 //
-// - Store API tokens securely - avoid hardcoding them in source code or configuration files
+// - Store API tokens and encryption keys securely - avoid hardcoding them in source code or configuration files
 // - Use appropriate priority levels - high priority notifications bypass quiet hours and should be reserved for critical events
 // - Consider device-specific targeting when needed using the devices parameter
-// - The user key is not secret, but the API token should be treated as a secret
+// - The user key is not secret, but the API token and encryption key should be treated as secrets
+// - When encryptionkey is set, message and title are encrypted client-side; an invalid key or encryption failure refuses to send
 // - Pushover notifications may contain sensitive information - consider this when sending notifications
 // - Review Pushover's terms of service for any usage restrictions
 //
@@ -145,5 +154,6 @@
 // - The Pushover API endpoint is https://api.pushover.net/1/messages.json
 // - Notifications are delivered instantly under normal conditions
 // - Priority -2 messages are stored for 7 days, -1 and 0 for 30 days, 1 for 7 days
-// - Maximum message length is 1024 characters
+// - Maximum message length is 1024 characters; encrypted fields are larger than plaintext and can exceed this limit
+// - End-to-end encryption is supported by the Pushover iOS and Android apps when the same key is configured on the device
 package pushover

--- a/pkg/services/push/pushover/doc.go
+++ b/pkg/services/push/pushover/doc.go
@@ -113,7 +113,7 @@
 //
 // Encrypt message and title with a 256-bit key also configured in the Pushover app:
 //
-//	url := "pushover://userkey:apitoken@?encryptionkey=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+//	url := "pushover://:apitoken@userkey?encryptionkey=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 //	err := shoutrrr.Send(url, "This message is encrypted")
 //
 // # Error Handling

--- a/pkg/services/push/pushover/pushover.go
+++ b/pkg/services/push/pushover/pushover.go
@@ -62,6 +62,10 @@ func (s *Service) Send(message string, params *types.Params) error {
 		return fmt.Errorf("updating config from params: %w", err)
 	}
 
+	if _, err := parseEncryptionKey(config.EncryptionKey); err != nil {
+		return err
+	}
+
 	device := strings.Join(config.Devices, ",")
 	if err := s.sendToDevice(device, message, config); err != nil {
 		return fmt.Errorf("failed to send notifications to pushover devices: %w", err)
@@ -86,6 +90,18 @@ func (s *Service) httpClientOrDefault() types.HTTPClient {
 
 // sendToDevice sends a notification to a specific Pushover device.
 func (s *Service) sendToDevice(device, message string, config *Config) error {
+	key, err := parseEncryptionKey(config.EncryptionKey)
+	if err != nil {
+		return err
+	}
+
+	if key != nil {
+		message, err = encryptField(message, key)
+		if err != nil {
+			return err
+		}
+	}
+
 	data := url.Values{}
 	data.Set("device", device)
 	data.Set("user", config.User)
@@ -93,7 +109,19 @@ func (s *Service) sendToDevice(device, message string, config *Config) error {
 	data.Set("message", message)
 
 	if config.Title != "" {
-		data.Set("title", config.Title)
+		title := config.Title
+		if key != nil {
+			title, err = encryptField(title, key)
+			if err != nil {
+				return err
+			}
+		}
+
+		data.Set("title", title)
+	}
+
+	if key != nil {
+		data.Set("encrypted", "1")
 	}
 
 	if config.Priority >= -2 && config.Priority <= 1 {

--- a/pkg/services/push/pushover/pushover_config.go
+++ b/pkg/services/push/pushover/pushover_config.go
@@ -10,11 +10,12 @@ import (
 
 // Config for the Pushover notification service.
 type Config struct {
-	Token    string   `desc:"API Token/Key" url:"pass"`
-	User     string   `desc:"User Key"      url:"host"`
-	Devices  []string `                                key:"devices"  optional:""`
-	Priority int8     `                                key:"priority"             default:"0"`
-	Title    string   `                                key:"title"    optional:""`
+	Token         string   `desc:"API Token/Key"                                                  url:"pass"`
+	User          string   `desc:"User Key"                                                       url:"host"`
+	Devices       []string `                                                                                 key:"devices"           optional:""`
+	Priority      int8     `                                                                                 key:"priority"                      default:"0"`
+	Title         string   `                                                                                 key:"title"             optional:""`
+	EncryptionKey string   `desc:"256-bit AES key as 64 hex characters for end-to-end encryption"            key:"encryptionkey,key" optional:""`
 }
 
 // Scheme is the identifying part of this service's configuration URL.
@@ -60,6 +61,10 @@ func (c *Config) setURL(resolver types.ConfigQueryResolver, serviceURL *url.URL)
 		if err := resolver.Set(key, vals[0]); err != nil {
 			return fmt.Errorf("setting query parameter %q to %q: %w", key, vals[0], err)
 		}
+	}
+
+	if _, err := parseEncryptionKey(c.EncryptionKey); err != nil {
+		return err
 	}
 
 	if serviceURL.String() != "pushover://dummy@dummy.com" {

--- a/pkg/services/push/pushover/pushover_config.go
+++ b/pkg/services/push/pushover/pushover_config.go
@@ -18,8 +18,13 @@ type Config struct {
 	EncryptionKey string   `desc:"256-bit AES key as 64 hex characters for end-to-end encryption"            key:"encryptionkey,key" optional:""`
 }
 
-// Scheme is the identifying part of this service's configuration URL.
-const Scheme = "pushover"
+const (
+	// Scheme is the identifying part of this service's configuration URL.
+	Scheme = "pushover"
+
+	// redactedPlaceholder replaces secrets when a Pushover URL is masked.
+	redactedPlaceholder = "REDACTED"
+)
 
 // Enums returns the fields that should use a corresponding EnumFormatter to Print/Parse their values.
 func (c *Config) Enums() map[string]types.EnumFormatter {
@@ -78,4 +83,37 @@ func (c *Config) setURL(resolver types.ConfigQueryResolver, serviceURL *url.URL)
 	}
 
 	return nil
+}
+
+// MaskURL redacts the API token in URL userinfo and sensitive query parameters.
+//
+// Parameters:
+//   - parsedURL: The Pushover URL to modify.
+func MaskURL(parsedURL *url.URL) {
+	if parsedURL == nil {
+		return
+	}
+
+	if parsedURL.User != nil {
+		parsedURL.User = url.UserPassword(parsedURL.User.Username(), redactedPlaceholder)
+	}
+
+	queryParams := parsedURL.Query()
+	if queryParams.Get("token") != "" {
+		queryParams.Set("token", redactedPlaceholder)
+	}
+
+	if queryParams.Get("user") != "" {
+		queryParams.Set("user", redactedPlaceholder)
+	}
+
+	if queryParams.Get("encryptionkey") != "" {
+		queryParams.Set("encryptionkey", redactedPlaceholder)
+	}
+
+	if queryParams.Get("key") != "" {
+		queryParams.Set("key", redactedPlaceholder)
+	}
+
+	parsedURL.RawQuery = queryParams.Encode()
 }

--- a/pkg/services/push/pushover/pushover_encrypt.go
+++ b/pkg/services/push/pushover/pushover_encrypt.go
@@ -1,0 +1,136 @@
+package pushover
+
+import (
+	"bytes"
+	"compress/gzip"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+)
+
+const encryptionKeySize = 32
+
+// parseEncryptionKey decodes a 64-character hex AES-256 key.
+//
+// An empty key disables E2EE and returns a nil slice.
+//
+// Parameters:
+//   - hexKey: 64-character hexadecimal string, or empty to disable encryption.
+//
+// Returns:
+//   - key: 32-byte AES key, or nil when hexKey is empty.
+//   - err: ErrInvalidEncryptionKey when hexKey is non-empty but not 32 decoded bytes.
+func parseEncryptionKey(hexKey string) ([]byte, error) {
+	if hexKey == "" {
+		return nil, nil
+	}
+
+	key, err := hex.DecodeString(hexKey)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidEncryptionKey, err)
+	}
+
+	if len(key) != encryptionKeySize {
+		return nil, fmt.Errorf("%w: got %d bytes, want %d", ErrInvalidEncryptionKey, len(key), encryptionKeySize)
+	}
+
+	return key, nil
+}
+
+// encryptField encrypts a single Pushover field using the documented E2EE scheme.
+//
+// The plaintext is gzip-compressed, encrypted with AES-256-CBC and PKCS7 padding,
+// authenticated with HMAC-SHA256 over IV||ciphertext, then Base64-encoded.
+//
+// Parameters:
+//   - plaintext: UTF-8 field value to encrypt.
+//   - key: 32-byte AES-256 key.
+//
+// Returns:
+//   - ciphertext: Base64-encoded IV||ciphertext||HMAC.
+//   - err: ErrEncryptionFailed when compression, padding, or encryption fails.
+func encryptField(plaintext string, key []byte) (string, error) {
+	var compressed bytes.Buffer
+
+	writer, err := gzip.NewWriterLevel(&compressed, gzip.BestCompression)
+	if err != nil {
+		return "", fmt.Errorf("%w: gzip: %w", ErrEncryptionFailed, err)
+	}
+
+	if _, err := writer.Write([]byte(plaintext)); err != nil {
+		return "", fmt.Errorf("%w: gzip: %w", ErrEncryptionFailed, err)
+	}
+
+	if err := writer.Close(); err != nil {
+		return "", fmt.Errorf("%w: gzip close: %w", ErrEncryptionFailed, err)
+	}
+
+	padded, err := pkcs7Pad(compressed.Bytes(), aes.BlockSize)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrEncryptionFailed, err)
+	}
+
+	initVector := make([]byte, aes.BlockSize)
+	if _, err := rand.Read(initVector); err != nil {
+		return "", fmt.Errorf("%w: iv: %w", ErrEncryptionFailed, err)
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", fmt.Errorf("%w: cipher: %w", ErrEncryptionFailed, err)
+	}
+
+	ciphertext := make([]byte, len(padded))
+	cipher.NewCBCEncrypter(block, initVector).CryptBlocks(ciphertext, padded)
+
+	mac := hmac.New(sha256.New, key)
+	if _, err := mac.Write(initVector); err != nil {
+		return "", fmt.Errorf("%w: hmac: %w", ErrEncryptionFailed, err)
+	}
+
+	if _, err := mac.Write(ciphertext); err != nil {
+		return "", fmt.Errorf("%w: hmac: %w", ErrEncryptionFailed, err)
+	}
+
+	payload := make([]byte, 0, len(initVector)+len(ciphertext)+sha256.Size)
+	payload = append(payload, initVector...)
+	payload = append(payload, ciphertext...)
+	payload = append(payload, mac.Sum(nil)...)
+
+	return base64.StdEncoding.EncodeToString(payload), nil
+}
+
+// pkcs7Pad appends PKCS7 padding so data is a multiple of blockSize.
+//
+// Parameters:
+//   - data: bytes to pad.
+//   - blockSize: AES block size in bytes.
+//
+// Returns:
+//   - padded: a new slice containing data followed by PKCS7 padding.
+//   - err: ErrEncryptionFailed when blockSize is invalid.
+func pkcs7Pad(data []byte, blockSize int) ([]byte, error) {
+	if blockSize <= 0 || blockSize > 255 {
+		return nil, fmt.Errorf("%w: invalid block size %d", ErrEncryptionFailed, blockSize)
+	}
+
+	padLen := blockSize - (len(data) % blockSize)
+	if padLen < 1 || padLen > 255 {
+		return nil, fmt.Errorf("%w: invalid pad length %d", ErrEncryptionFailed, padLen)
+	}
+
+	padByte := byte(padLen)
+	padded := make([]byte, len(data)+padLen)
+	copy(padded, data)
+
+	for i := len(data); i < len(padded); i++ {
+		padded[i] = padByte
+	}
+
+	return padded, nil
+}

--- a/pkg/services/push/pushover/pushover_error.go
+++ b/pkg/services/push/pushover/pushover_error.go
@@ -2,11 +2,19 @@ package pushover
 
 import "errors"
 
-// ErrSendFailed indicates a failure in sending the notification to a Pushover device.
-var ErrSendFailed = errors.New("failed to send notification to pushover device")
+var (
+	// ErrSendFailed indicates a failure in sending the notification to a Pushover device.
+	ErrSendFailed = errors.New("failed to send notification to pushover device")
 
-// ErrUserMissing indicates the user key is missing from the Pushover config URL.
-var ErrUserMissing = errors.New("user missing from config URL")
+	// ErrUserMissing indicates the user key is missing from the Pushover config URL.
+	ErrUserMissing = errors.New("user missing from config URL")
 
-// ErrTokenMissing indicates the API token is missing from the Pushover config URL.
-var ErrTokenMissing = errors.New("token missing from config URL")
+	// ErrTokenMissing indicates the API token is missing from the Pushover config URL.
+	ErrTokenMissing = errors.New("token missing from config URL")
+
+	// ErrInvalidEncryptionKey indicates the E2EE key is not a 64-character hex string.
+	ErrInvalidEncryptionKey = errors.New("invalid encryption key")
+
+	// ErrEncryptionFailed indicates a failure while encrypting a Pushover field.
+	ErrEncryptionFailed = errors.New("encryption failed")
+)

--- a/pkg/services/push/pushover/pushover_test.go
+++ b/pkg/services/push/pushover/pushover_test.go
@@ -1,8 +1,18 @@
 package pushover_test
 
 import (
+	"bytes"
+	"compress/gzip"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
 	"errors"
+	"io"
 	"log"
+	"net/http"
 	"net/url"
 	"os"
 	"testing"
@@ -14,9 +24,14 @@ import (
 	"github.com/nicholas-fedor/shoutrrr/internal/testutils"
 	"github.com/nicholas-fedor/shoutrrr/pkg/format"
 	"github.com/nicholas-fedor/shoutrrr/pkg/services/push/pushover"
+	"github.com/nicholas-fedor/shoutrrr/pkg/types"
 )
 
-const hookURL = "https://api.pushover.net/1/messages.json"
+const (
+	hookURL                = "https://api.pushover.net/1/messages.json"
+	testEncryptionKey      = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	testEncryptionKeyMixed = "0123456789ABCDEF0123456789abcdef0123456789ABCDEF0123456789abcdef"
+)
 
 var (
 	service        *pushover.Service
@@ -120,6 +135,11 @@ var _ = ginkgo.Describe("the pushover config", func() {
 			err := keyResolver.Set("devicey", "a,b,c,d")
 			gomega.Expect(err).To(gomega.HaveOccurred())
 		})
+		ginkgo.It("should accept the encryption key alias", func() {
+			err := keyResolver.Set("key", testEncryptionKey)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(config.EncryptionKey).To(gomega.Equal(testEncryptionKey))
+		})
 	})
 	ginkgo.When("getting a config key", func() {
 		ginkgo.It("should join it with commas if the key is devices", func() {
@@ -135,9 +155,63 @@ var _ = ginkgo.Describe("the pushover config", func() {
 	})
 
 	ginkgo.When("listing the query fields", func() {
-		ginkgo.It("should return the keys \"devices\",\"priority\",\"title\"", func() {
+		ginkgo.It("should return the keys \"devices\",\"encryptionkey\",\"key\",\"priority\",\"title\"", func() {
 			fields := keyResolver.QueryFields()
-			gomega.Expect(fields).To(gomega.Equal([]string{"devices", "priority", "title"}))
+			gomega.Expect(fields).To(gomega.Equal([]string{
+				"devices",
+				"encryptionkey",
+				"key",
+				"priority",
+				"title",
+			}))
+		})
+	})
+
+	ginkgo.When("configuring end-to-end encryption", func() {
+		ginkgo.It("should accept a mixed-case 64-character hex key", func() {
+			serviceURL, err := url.Parse(
+				"pushover://:apptoken@usertoken?encryptionkey=" + testEncryptionKeyMixed,
+			)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = config.SetURL(serviceURL)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(config.EncryptionKey).To(gomega.Equal(testEncryptionKeyMixed))
+		})
+		ginkgo.It("should reject a short encryption key", func() {
+			serviceURL, err := url.Parse("pushover://:apptoken@usertoken?encryptionkey=0123456789abcdef")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = config.SetURL(serviceURL)
+			gomega.Expect(err).To(gomega.MatchError(pushover.ErrInvalidEncryptionKey))
+		})
+		ginkgo.It("should reject a long encryption key", func() {
+			serviceURL, err := url.Parse(
+				"pushover://:apptoken@usertoken?encryptionkey=" + testEncryptionKey + "ab",
+			)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = config.SetURL(serviceURL)
+			gomega.Expect(err).To(gomega.MatchError(pushover.ErrInvalidEncryptionKey))
+		})
+		ginkgo.It("should reject a non-hex encryption key", func() {
+			serviceURL, err := url.Parse(
+				"pushover://:apptoken@usertoken?encryptionkey=zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+			)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = config.SetURL(serviceURL)
+			gomega.Expect(err).To(gomega.MatchError(pushover.ErrInvalidEncryptionKey))
+		})
+		ginkgo.It("should round-trip the encryption key through GetURL", func() {
+			config.User = "simme"
+			config.Token = "test-token"
+			config.EncryptionKey = testEncryptionKey
+
+			serviceURL := config.GetURL()
+			gomega.Expect(serviceURL.Query().Get("encryptionkey")).To(gomega.Equal(testEncryptionKey))
+			gomega.Expect(serviceURL.Query().Get("key")).To(gomega.BeEmpty())
+
+			roundTrip := &pushover.Config{}
+			err := roundTrip.SetURL(serviceURL)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(roundTrip.EncryptionKey).To(gomega.Equal(testEncryptionKey))
 		})
 	})
 
@@ -176,6 +250,95 @@ var _ = ginkgo.Describe("the pushover config", func() {
 			err = service.Send("Message", nil)
 			gomega.Expect(err).To(gomega.HaveOccurred())
 		})
+		ginkgo.It("should send plaintext without an encrypted flag when no key is set", func() {
+			serviceURL, err := url.Parse("pushover://:apptoken@usertoken?title=Plain+Title")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			err = service.Initialize(serviceURL, logger)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			httpmock.RegisterResponder(
+				"POST",
+				hookURL,
+				func(req *http.Request) (*http.Response, error) {
+					gomega.Expect(req.ParseForm()).To(gomega.Succeed())
+					gomega.Expect(req.Form.Get("encrypted")).To(gomega.BeEmpty())
+					gomega.Expect(req.Form.Get("message")).To(gomega.Equal("Message"))
+					gomega.Expect(req.Form.Get("title")).To(gomega.Equal("Plain Title"))
+
+					return httpmock.NewStringResponse(200, ""), nil
+				},
+			)
+
+			err = service.Send("Message", nil)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+		ginkgo.It("should encrypt message and title when an encryption key is set", func() {
+			serviceURL, err := url.Parse(
+				"pushover://:apptoken@usertoken?encryptionkey=" +
+					testEncryptionKey +
+					"&title=Secret+Title",
+			)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			err = service.Initialize(serviceURL, logger)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			keyBytes, err := hex.DecodeString(testEncryptionKey)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			httpmock.RegisterResponder(
+				"POST",
+				hookURL,
+				func(req *http.Request) (*http.Response, error) {
+					gomega.Expect(req.ParseForm()).To(gomega.Succeed())
+					gomega.Expect(req.Form.Get("encrypted")).To(gomega.Equal("1"))
+					gomega.Expect(req.Form.Get("message")).NotTo(gomega.Equal("Secret message"))
+					gomega.Expect(req.Form.Get("title")).NotTo(gomega.Equal("Secret Title"))
+
+					message, decErr := decryptPushoverField(req.Form.Get("message"), keyBytes)
+					gomega.Expect(decErr).NotTo(gomega.HaveOccurred())
+					gomega.Expect(message).To(gomega.Equal("Secret message"))
+
+					title, decErr := decryptPushoverField(req.Form.Get("title"), keyBytes)
+					gomega.Expect(decErr).NotTo(gomega.HaveOccurred())
+					gomega.Expect(title).To(gomega.Equal("Secret Title"))
+
+					return httpmock.NewStringResponse(200, ""), nil
+				},
+			)
+
+			err = service.Send("Secret message", nil)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+		ginkgo.It("should fail to initialize when the encryption key is invalid", func() {
+			serviceURL, err := url.Parse("pushover://:apptoken@usertoken?encryptionkey=short")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			err = service.Initialize(serviceURL, logger)
+			gomega.Expect(err).To(gomega.MatchError(pushover.ErrInvalidEncryptionKey))
+		})
+		ginkgo.It("should not send when params supply an invalid encryption key", func() {
+			serviceURL, err := url.Parse("pushover://:apptoken@usertoken")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			err = service.Initialize(serviceURL, logger)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			httpmock.RegisterResponder(
+				"POST",
+				hookURL,
+				func(*http.Request) (*http.Response, error) {
+					ginkgo.Fail("HTTP request should not be sent")
+
+					return nil, errors.New("unexpected HTTP request")
+				},
+			)
+
+			err = service.Send("Message", &types.Params{"encryptionkey": "short"})
+			gomega.Expect(err).To(gomega.MatchError(pushover.ErrInvalidEncryptionKey))
+			gomega.Expect(httpmock.GetTotalCallCount()).To(gomega.Equal(0))
+		})
 	})
 })
 
@@ -196,4 +359,85 @@ func expectErrorGivenURL(expectedErr error, serviceURL *url.URL) {
 	err := config.SetURL(serviceURL)
 	gomega.Expect(err).To(gomega.HaveOccurred())
 	gomega.Expect(err.Error()).To(gomega.Equal(expectedErr.Error()))
+}
+
+func decryptPushoverField(encoded string, key []byte) (string, error) {
+	payload, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return "", err
+	}
+
+	const hmacSize = sha256.Size
+	if len(payload) < aes.BlockSize+hmacSize {
+		return "", errors.New("ciphertext too short")
+	}
+
+	iv := payload[:aes.BlockSize]
+	mac := payload[len(payload)-hmacSize:]
+	ciphertext := payload[aes.BlockSize : len(payload)-hmacSize]
+
+	expected := hmac.New(sha256.New, key)
+	if _, err := expected.Write(iv); err != nil {
+		return "", err
+	}
+
+	if _, err := expected.Write(ciphertext); err != nil {
+		return "", err
+	}
+
+	if !hmac.Equal(mac, expected.Sum(nil)) {
+		return "", errors.New("hmac mismatch")
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+
+	if len(ciphertext)%aes.BlockSize != 0 {
+		return "", errors.New("ciphertext not a multiple of block size")
+	}
+
+	plain := make([]byte, len(ciphertext))
+	cipher.NewCBCDecrypter(block, iv).CryptBlocks(plain, ciphertext)
+
+	unpadded, err := pkcs7Unpad(plain, aes.BlockSize)
+	if err != nil {
+		return "", err
+	}
+
+	reader, err := gzip.NewReader(bytes.NewReader(unpadded))
+	if err != nil {
+		return "", err
+	}
+
+	decompressed, err := io.ReadAll(reader)
+	if err != nil {
+		return "", err
+	}
+
+	if err := reader.Close(); err != nil {
+		return "", err
+	}
+
+	return string(decompressed), nil
+}
+
+func pkcs7Unpad(data []byte, blockSize int) ([]byte, error) {
+	if len(data) == 0 || len(data)%blockSize != 0 {
+		return nil, errors.New("invalid padding")
+	}
+
+	padLen := int(data[len(data)-1])
+	if padLen == 0 || padLen > blockSize || padLen > len(data) {
+		return nil, errors.New("invalid padding")
+	}
+
+	for _, b := range data[len(data)-padLen:] {
+		if b != byte(padLen) {
+			return nil, errors.New("invalid padding")
+		}
+	}
+
+	return data[:len(data)-padLen], nil
 }

--- a/shoutrrr/cmd/generate/generate.go
+++ b/shoutrrr/cmd/generate/generate.go
@@ -275,11 +275,16 @@ func maskSMTPUser(parsedURL *url.URL) {
 	}
 }
 
-// maskPushoverQuery redacts token and user query parameters in a Pushover URL.
+// maskPushoverQuery redacts the API token in URL userinfo and sensitive query
+// parameters in a Pushover URL.
 //
 // Parameters:
 //   - parsedURL: The Pushover URL to modify.
 func maskPushoverQuery(parsedURL *url.URL) {
+	if parsedURL.User != nil {
+		parsedURL.User = url.UserPassword(parsedURL.User.Username(), redactedStr)
+	}
+
 	queryParams := parsedURL.Query()
 	if queryParams.Get("token") != "" {
 		queryParams.Set("token", redactedStr)
@@ -287,6 +292,14 @@ func maskPushoverQuery(parsedURL *url.URL) {
 
 	if queryParams.Get("user") != "" {
 		queryParams.Set("user", redactedStr)
+	}
+
+	if queryParams.Get("encryptionkey") != "" {
+		queryParams.Set("encryptionkey", redactedStr)
+	}
+
+	if queryParams.Get("key") != "" {
+		queryParams.Set("key", redactedStr)
 	}
 
 	parsedURL.RawQuery = queryParams.Encode()

--- a/shoutrrr/cmd/generate/generate.go
+++ b/shoutrrr/cmd/generate/generate.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nicholas-fedor/shoutrrr/pkg/color"
 	"github.com/nicholas-fedor/shoutrrr/pkg/generators"
 	"github.com/nicholas-fedor/shoutrrr/pkg/router"
+	"github.com/nicholas-fedor/shoutrrr/pkg/services/push/pushover"
 	"github.com/nicholas-fedor/shoutrrr/pkg/types"
 )
 
@@ -281,28 +282,7 @@ func maskSMTPUser(parsedURL *url.URL) {
 // Parameters:
 //   - parsedURL: The Pushover URL to modify.
 func maskPushoverQuery(parsedURL *url.URL) {
-	if parsedURL.User != nil {
-		parsedURL.User = url.UserPassword(parsedURL.User.Username(), redactedStr)
-	}
-
-	queryParams := parsedURL.Query()
-	if queryParams.Get("token") != "" {
-		queryParams.Set("token", redactedStr)
-	}
-
-	if queryParams.Get("user") != "" {
-		queryParams.Set("user", redactedStr)
-	}
-
-	if queryParams.Get("encryptionkey") != "" {
-		queryParams.Set("encryptionkey", redactedStr)
-	}
-
-	if queryParams.Get("key") != "" {
-		queryParams.Set("key", redactedStr)
-	}
-
-	parsedURL.RawQuery = queryParams.Encode()
+	pushover.MaskURL(parsedURL)
 }
 
 // maskGotifyQuery redacts the token query parameter in a Gotify URL.

--- a/shoutrrr/cmd/generate/generate_test.go
+++ b/shoutrrr/cmd/generate/generate_test.go
@@ -265,12 +265,13 @@ func Test_maskPushoverQuery(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		urlStr   string
-		wantTok  string
-		wantUser string
-		wantKey  string
-		wantPass string
+		name         string
+		urlStr       string
+		wantTok      string
+		wantUser     string
+		wantKey      string
+		wantKeyParam string
+		wantPass     string
 	}{
 		{
 			name:     "masks token and user",
@@ -291,14 +292,16 @@ func Test_maskPushoverQuery(t *testing.T) {
 			wantUser: "",
 		},
 		{
-			name:    "masks encryptionkey query parameter",
-			urlStr:  "pushover://?encryptionkey=secret-hex-key",
-			wantKey: redactedStr,
+			name:         "masks encryptionkey query parameter",
+			urlStr:       "pushover://?encryptionkey=secret-hex-key",
+			wantKey:      redactedStr,
+			wantKeyParam: "encryptionkey",
 		},
 		{
-			name:    "masks key alias query parameter",
-			urlStr:  "pushover://?key=secret-hex-key",
-			wantKey: redactedStr,
+			name:         "masks key alias query parameter",
+			urlStr:       "pushover://?key=secret-hex-key",
+			wantKey:      redactedStr,
+			wantKeyParam: "key",
 		},
 		{
 			name:     "masks API token in URL userinfo",
@@ -325,14 +328,9 @@ func Test_maskPushoverQuery(t *testing.T) {
 				assert.Equal(t, tt.wantUser, query.Get("user"), "user mismatch")
 			}
 
-			if tt.wantKey != "" {
-				if query.Has("encryptionkey") {
-					assert.Equal(t, tt.wantKey, query.Get("encryptionkey"), "encryptionkey mismatch")
-				}
-
-				if query.Has("key") {
-					assert.Equal(t, tt.wantKey, query.Get("key"), "key mismatch")
-				}
+			if tt.wantKeyParam != "" {
+				require.True(t, query.Has(tt.wantKeyParam), "expected %s to be present", tt.wantKeyParam)
+				assert.Equal(t, tt.wantKey, query.Get(tt.wantKeyParam), tt.wantKeyParam+" mismatch")
 			}
 
 			if tt.wantPass != "" {

--- a/shoutrrr/cmd/generate/generate_test.go
+++ b/shoutrrr/cmd/generate/generate_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/nicholas-fedor/shoutrrr/pkg/services/push/pushover"
 )
 
 // Test_loadArgsFromAltSources tests the loadArgsFromAltSources function with various scenarios.
@@ -109,6 +111,12 @@ func Test_maskSensitiveURL(t *testing.T) {
 			want:          "pushover://pushover.net?token=REDACTED&user=REDACTED",
 		},
 		{
+			name:          "pushover service masks userinfo token and encryption key",
+			serviceSchema: "pushover",
+			urlStr:        "pushover://Token:secret-api-token@userkey/?encryptionkey=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			want:          "pushover://Token:REDACTED@userkey/?encryptionkey=REDACTED",
+		},
+		{
 			name:          "gotify service masks token",
 			serviceSchema: "gotify",
 			urlStr:        "gotify://gotify.net?token=secret",
@@ -136,6 +144,24 @@ func Test_maskSensitiveURL(t *testing.T) {
 			assert.Equal(t, tt.want, got, "maskSensitiveURL() returned unexpected value")
 		})
 	}
+}
+
+// Test_maskSensitiveURL_pushoverGeneratePath verifies that the default generate
+// path redacts both Config.Token and Config.EncryptionKey.
+func Test_maskSensitiveURL_pushoverGeneratePath(t *testing.T) {
+	t.Parallel()
+
+	cfg := &pushover.Config{
+		Token:         "secret-api-token",
+		User:          "userkey",
+		EncryptionKey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+	}
+
+	masked := maskSensitiveURL(pushover.Scheme, cfg.GetURL().String())
+
+	assert.NotContains(t, masked, cfg.Token, "API token must not appear in the masked URL")
+	assert.NotContains(t, masked, cfg.EncryptionKey, "encryption key must not appear in the masked URL")
+	assert.Contains(t, masked, redactedStr, "masked URL should contain the redaction placeholder")
 }
 
 // Test_maskUser tests the maskUser function.
@@ -243,6 +269,8 @@ func Test_maskPushoverQuery(t *testing.T) {
 		urlStr   string
 		wantTok  string
 		wantUser string
+		wantKey  string
+		wantPass string
 	}{
 		{
 			name:     "masks token and user",
@@ -261,6 +289,21 @@ func Test_maskPushoverQuery(t *testing.T) {
 			urlStr:   "pushover://?other=value",
 			wantTok:  "",
 			wantUser: "",
+		},
+		{
+			name:    "masks encryptionkey query parameter",
+			urlStr:  "pushover://?encryptionkey=secret-hex-key",
+			wantKey: redactedStr,
+		},
+		{
+			name:    "masks key alias query parameter",
+			urlStr:  "pushover://?key=secret-hex-key",
+			wantKey: redactedStr,
+		},
+		{
+			name:     "masks API token in URL userinfo",
+			urlStr:   "pushover://Token:secret-api-token@userkey/",
+			wantPass: redactedStr,
 		},
 	}
 
@@ -282,7 +325,23 @@ func Test_maskPushoverQuery(t *testing.T) {
 				assert.Equal(t, tt.wantUser, query.Get("user"), "user mismatch")
 			}
 
-			if tt.wantTok == "" && tt.wantUser == "" {
+			if tt.wantKey != "" {
+				if query.Has("encryptionkey") {
+					assert.Equal(t, tt.wantKey, query.Get("encryptionkey"), "encryptionkey mismatch")
+				}
+
+				if query.Has("key") {
+					assert.Equal(t, tt.wantKey, query.Get("key"), "key mismatch")
+				}
+			}
+
+			if tt.wantPass != "" {
+				pass, hasPass := parsedURL.User.Password()
+				assert.True(t, hasPass, "password should be set")
+				assert.Equal(t, tt.wantPass, pass, "userinfo token mismatch")
+			}
+
+			if tt.wantTok == "" && tt.wantUser == "" && tt.wantKey == "" && tt.wantPass == "" {
 				// Verify other params are unchanged
 				assert.Equal(t, "value", query.Get("other"), "other param should be unchanged")
 			}


### PR DESCRIPTION
This PR adds optional end-to-end encryption for Pushover notifications. When a 256-bit key is present in the service URL, message and title are encrypted client-side before they are sent. Invalid keys and encryption failures refuse to send instead of falling back to plaintext.

## Problem

Pushover supports end-to-end encryption, but Shoutrrr sent message and title in plaintext. Generated service URLs could also expose the API token and encryption key.

## Solution

Pushover message and title are encrypted when an encryption key is configured, and sending is refused if the key is invalid or encryption fails. Generated URLs redact the API token and encryption key.

## Changes

- Add Pushover E2EE via the `encryptionkey` query parameter (`key` alias).
- Encrypt message and title and send `encrypted=1` when a key is set.
- Redact the API token and encryption key in generate URL masking.
- Document Pushover end-to-end encryption usage.