### PR TITLE
fix(smtp): RFC 2047 encode non-ASCII Subject and From headers

### DIFF
--- a/pkg/services/email/smtp/smtp.go
+++ b/pkg/services/email/smtp/smtp.go
@@ -8,7 +8,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"net"
+	"net/mail"
 	"net/smtp"
 	"net/url"
 	"os"
@@ -269,11 +271,15 @@ func (s *Service) getHeaders(toAddress, subject string) map[string]string {
 		contentType = contentPlain
 	}
 
+	// Header values must be US-ASCII (RFC 5322 2.2), so any non-ASCII content is
+	// wrapped in RFC 2047 encoded-words. Pure ASCII values are passed through as-is.
+	from := &mail.Address{Name: conf.FromName, Address: conf.FromAddress}
+
 	return map[string]string{
-		"Subject":      subject,
+		"Subject":      mime.QEncoding.Encode("UTF-8", subject),
 		"Date":         time.Now().Format(time.RFC1123Z),
 		"To":           toAddress,
-		"From":         fmt.Sprintf("%s <%s>", conf.FromName, conf.FromAddress),
+		"From":         from.String(),
 		"MIME-version": "1.0",
 		"Content-Type": contentType,
 	}

--- a/pkg/services/email/smtp/smtp_test.go
+++ b/pkg/services/email/smtp/smtp_test.go
@@ -157,10 +157,30 @@ var _ = ginkgo.Describe("the SMTP service", func() {
 					}
 					headers := service.getHeaders("rec1@example.com", "Subject")
 
+					gomega.Expect(headers["From"]).
+						To(gomega.Equal("=?utf-8?q?Gr=C3=BC=C3=9Fer?= <sender@example.com>"))
+
 					address, err := mail.ParseAddress(headers["From"])
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					gomega.Expect(address.Name).To(gomega.Equal("Grüßer"))
 					gomega.Expect(address.Address).To(gomega.Equal("sender@example.com"))
+				})
+			})
+			ginkgo.When("the sender name or address requires quoting", func() {
+				ginkgo.It("should quote them", func() {
+					service.Config = &Config{
+						FromName:    "Doe, John",
+						FromAddress: "odd name@example.com",
+					}
+					headers := service.getHeaders("rec1@example.com", "Subject")
+
+					gomega.Expect(headers["From"]).
+						To(gomega.Equal(`"Doe, John" <"odd name"@example.com>`))
+					gomega.Expect(mail.ParseAddress(headers["From"])).
+						To(gomega.Equal(&mail.Address{
+							Name:    "Doe, John",
+							Address: `odd name@example.com`,
+						}))
 				})
 			})
 			ginkgo.When("no sender name is configured", func() {

--- a/pkg/services/email/smtp/smtp_test.go
+++ b/pkg/services/email/smtp/smtp_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"errors"
 	"log"
+	"mime"
 	"net"
+	"net/mail"
 	"net/smtp"
 	"net/url"
 	"os"
@@ -124,6 +126,49 @@ var _ = ginkgo.Describe("the SMTP service", func() {
 				ginkgo.It("should return that value", func() {
 					gomega.Expect(service.resolveClientHost(&Config{ClientHost: "computah"})).
 						To(gomega.Equal("computah"))
+				})
+			})
+		})
+		ginkgo.When("constructing the message headers", func() {
+			ginkgo.When("the subject contains non-ASCII characters", func() {
+				ginkgo.It("should encode it as an RFC 2047 encoded-word", func() {
+					service.Config = &Config{FromAddress: "sender@example.com"}
+					headers := service.getHeaders("rec1@example.com", "Plan überschritten")
+
+					gomega.Expect(headers["Subject"]).
+						To(gomega.Equal("=?UTF-8?q?Plan_=C3=BCberschritten?="))
+					gomega.Expect(new(mime.WordDecoder).DecodeHeader(headers["Subject"])).
+						To(gomega.Equal("Plan überschritten"))
+				})
+			})
+			ginkgo.When("the subject is pure ASCII", func() {
+				ginkgo.It("should leave it unencoded", func() {
+					service.Config = &Config{FromAddress: "sender@example.com"}
+					headers := service.getHeaders("rec1@example.com", "Plan exceeded")
+
+					gomega.Expect(headers["Subject"]).To(gomega.Equal("Plan exceeded"))
+				})
+			})
+			ginkgo.When("the sender name contains non-ASCII characters", func() {
+				ginkgo.It("should encode it and keep the address parseable", func() {
+					service.Config = &Config{
+						FromName:    "Grüßer",
+						FromAddress: "sender@example.com",
+					}
+					headers := service.getHeaders("rec1@example.com", "Subject")
+
+					address, err := mail.ParseAddress(headers["From"])
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					gomega.Expect(address.Name).To(gomega.Equal("Grüßer"))
+					gomega.Expect(address.Address).To(gomega.Equal("sender@example.com"))
+				})
+			})
+			ginkgo.When("no sender name is configured", func() {
+				ginkgo.It("should only emit the address", func() {
+					service.Config = &Config{FromAddress: "sender+tag@example.com"}
+					headers := service.getHeaders("rec1@example.com", "Subject")
+
+					gomega.Expect(headers["From"]).To(gomega.Equal("<sender+tag@example.com>"))
 				})
 			})
 		})
@@ -352,7 +397,7 @@ var _ = ginkgo.Describe("the SMTP service", func() {
 				}, "<pre>{{ .message }}</pre>", "{{ .message }}",
 					"RCPT TO:<rec1+tag@example.com>",
 					"To: rec1+tag@example.com",
-					"From:  <sender+tag@example.com>")
+					"From: <sender+tag@example.com>")
 				if msg, test := standard.IsTestSetupFailure(err); test {
 					ginkgo.Skip(msg)
 


### PR DESCRIPTION
Fixes #1252

RFC 5322 §2.2 restricts header field values to US-ASCII, so non-ASCII content has to be wrapped in RFC 2047 encoded-words. `getHeaders` passed the subject and the sender display name through unencoded, which put raw UTF-8 bytes on the wire and made receiving clients render `Plan überschritten` as `Plan Ã^CÂ¼berschritten`. The body was never affected, since it carries an explicit `charset="UTF-8"`.

## Changes

- `Subject` is encoded with `mime.QEncoding.Encode`. `WordEncoder.Encode` returns the input unchanged when it needs no encoding, so pure-ASCII subjects are byte-for-byte identical to before.
- `From` is built with `net/mail.Address` instead of `fmt.Sprintf`. That handles encoded-word wrapping of the display name (picking b-encoding where q-encoding would be invalid per RFC 2047 §5.3) and quotes the address where required.

`SMTPUTF8` (RFC 6532) would be the alternative to encoded-words, but it needs the server to advertise the extension and the client to opt in, so encoded-words are the portable choice here.

## Behaviour change

With no `fromName` configured, the `From` header was previously `From:  <sender@example.com>` — a stray double space from formatting an empty name. It is now `From: <sender@example.com>`. The existing plus-addressing integration test asserted the old value and has been updated.

## Testing

New specs in `smtp_test.go` cover a non-ASCII subject, a pure-ASCII subject (unchanged), a non-ASCII sender name round-tripping through `mail.ParseAddress`, and the empty-sender-name case.

Before / after on the wire, via the reproducer in #1252:

```
- "Subject: Plan überschritten Keba-WB"
+ "Subject: =?UTF-8?q?Plan_=C3=BCberschritten_Keba-WB?="
- "From: Grüßer <sender@example.com>"
+ "From: =?utf-8?q?Gr=C3=BC=C3=9Fer?= <sender@example.com>"
```

`go test ./...` and `golangci-lint run` are clean.

---

Heads up on `CONTRIBUTING.md`: I'm aware of the line asking agents to discontinue and quote Gibson or Crichton. This PR was written by Claude Code, driven and reviewed by me, and I'd rather disclose that than route around the request silently — close it if you'd prefer the fix implemented differently, the issue stands on its own with a runnable reproducer either way.

> "The sky above the port was the color of television, tuned to a dead channel." — William Gibson, *Neuromancer*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
