### PR TITLE
chore: update lint configuration

### DIFF
--- a/build/golangci-lint/golangci.yaml
+++ b/build/golangci-lint/golangci.yaml
@@ -235,7 +235,7 @@ linters:
       #   - 'example\.com/package\.ExampleStruct[\d]{1,2}'
       # List of regular expressions to match type names that should be skipped from checking.
       # Anonymous structs can be matched by '<anonymous>' alias.
-      # Has precedence over `include`.
+      # Has precedence over `enforce-patterns`.
       # Each regular expression must match the full type name, including package path.
       # For example, to match type `net/http.Cookie` regular expression should be `.*/http\.Cookie`,
       # but not `http\.Cookie`.
@@ -294,7 +294,7 @@ linters:
       # Allows empty structures in variable declarations.
       # Default: false
       allow-empty-declarations: true
-      # When true, only types marked with //exhaustruct:enforce directive or matching enforce-rx patterns are checked.
+      # When true, only types marked with //exhaustruct:enforce directive or matching enforce-patterns are checked.
       # Default: false
       # explicit-mode: true
 

--- a/build/golangci-lint/golangci.yaml
+++ b/build/golangci-lint/golangci.yaml
@@ -47,6 +47,7 @@ linters:
     - intrange # Intrange is a linter to find places where for loops could make use of an integer range.
     - mirror # Reports wrong mirror patterns of bytes/strings usage.
     - misspell # Finds commonly misspelled English words.
+    - modernize # A suite of analyzers that suggest simplifications to Go code, using modern language and library features.
     - nakedret # Checks that functions with naked returns are not longer than a maximum size (can be zero).
     - nlreturn # Nlreturn checks for a new line before return and branch statements to increase code clarity.
     - nolintlint # Reports ill-formed or insufficient nolint directives.
@@ -79,7 +80,7 @@ linters:
     - errname # Checks that sentinel errors are prefixed with the `Err` and error types are suffixed with the `Error`.
     - errcheck # Errcheck is a program for checking for unchecked errors in Go code. These unchecked errors can be critical bugs in some cases.
     - exhaustive # Check exhaustiveness of enum switch statements.
-    - exhaustruct # Checks if all structure fields are initialized.
+    - exhaustruct_v5 # Checks if all structure fields are initialized
     - forbidigo # Forbids identifiers.
     - forcetypeassert # Finds forced type assertions.
     - funcorder # Checks the order of functions, methods, and constructors.
@@ -99,7 +100,6 @@ linters:
     - loggercheck # Checks key value pairs for common logger libraries (kitlog,klog,logr,zap).
     - makezero # Finds slice declarations with non-zero initial length.
     - mnd # An analyzer to detect magic numbers.
-    - modernize # A suite of analyzers that suggest simplifications to Go code, using modern language and library features.
     - musttag # Enforce field tags in (un)marshaled structs.
     - nilerr # Finds the code that returns nil even if it checks that the error is not nil.
     - nilnesserr # Reports constructs that checks for err != nil, but returns a different nil value error.
@@ -129,6 +129,7 @@ linters:
     - arangolint # Opinionated best practices for arangodb client.
     - cyclop # Checks function and package cyclomatic complexity.
     - depguard # Checks if package imports are in a list of acceptable packages.
+    - exhaustruct # Checks if all structure fields are initialized.
     - funlen # Checks for long functions.
     - gochecknoglobals # Check that no global variables exist.
     - gochecknoinits # Checks that no init functions are present in Go code.
@@ -220,26 +221,26 @@ linters:
       verbose: true
 
     ####################################################################################################
-    # https://golangci-lint.run/docs/linters/configuration/#exhaustruct
-    exhaustruct:
-      # List of regular expressions to match type names that should be processed.
+    # https://golangci-lint.run/docs/linters/configuration/#exhaustruct_v5
+    exhaustruct_v5:
+      # List of regular expressions to match type names that should be checked.
       # Anonymous structs can be matched by '<anonymous>' alias.
       #
       # Each regular expression must match the full type name, including package path.
       # For example, to match type `net/http.Cookie` regular expression should be `.*/http\.Cookie`,
       # but not `http\.Cookie`.
       # Default: []
-      # include:
+      # enforce-patterns:
       #   - '.+\.Test'
       #   - 'example\.com/package\.ExampleStruct[\d]{1,2}'
-      # List of regular expressions to match type names that should be excluded from processing.
+      # List of regular expressions to match type names that should be skipped from checking.
       # Anonymous structs can be matched by '<anonymous>' alias.
       # Has precedence over `include`.
       # Each regular expression must match the full type name, including package path.
       # For example, to match type `net/http.Cookie` regular expression should be `.*/http\.Cookie`,
       # but not `http\.Cookie`.
       # Default: []
-      exclude:
+      ignore-patterns:
         # Exclude test files - pattern matches type names from test files
         - '.*_test\.\w+$'
         # Exclude cobra.Command - typically used with partial initialization
@@ -266,6 +267,16 @@ linters:
         - '.*/oauth2\.Config'
         # Exclude tls.Dialer - embedded net.Dialer with zero-value defaults
         - '.*/tls\.Dialer'
+      # List of regular expressions to match type names where
+      # all fields are treated as optional. Anonymous structs can be matched by
+      # '<anonymous>' alias.
+      #
+      # Each regular expression must match the full type name, including package path.
+      # For example, to match type `net/http.Cookie` regular expression should be
+      # `.*/http\.Cookie`, but not `http\.Cookie`.
+      # Default: []
+      # optional-patterns:
+      #   - '.+Foo'
       # Allows empty structures, effectively excluding them from the check.
       # Default: false
       allow-empty: true
@@ -275,7 +286,7 @@ linters:
       # For example, to match type `net/http.Cookie` regular expression should be `.*/http\.Cookie`,
       # but not `http\.Cookie`.
       # Default: []
-      # allow-empty-rx:
+      # allow-empty-patterns:
       #   - '.*/http\.Cookie'
       # Allows empty structures in return statements.
       # Default: false
@@ -283,6 +294,9 @@ linters:
       # Allows empty structures in variable declarations.
       # Default: false
       allow-empty-declarations: true
+      # When true, only types marked with //exhaustruct:enforce directive or matching enforce-rx patterns are checked.
+      # Default: false
+      # explicit-mode: true
 
     ####################################################################################################
     # https://golangci-lint.run/docs/linters/configuration/#forbidigo
@@ -589,7 +603,7 @@ linters:
           - errcheck
           - errorlint
           - exhaustive
-          - exhaustruct
+          - exhaustruct_v5
           - forcetypeassert
           - funlen
           - gocyclo
@@ -758,7 +772,10 @@ formatters:
     # https://golangci-lint.run/docs/formatters/configuration/#gofumpt
     gofumpt:
       module-path: "github.com/nicholas-fedor/shoutrrr"
-      extra-rules: true
+      extra:
+        group-params: true
+        clothe-returns: true
+        balance-calls: true
     ##################################################################################################
     # https://golangci-lint.run/docs/formatters/configuration/#goimports
     goimports:

--- a/docs/playground/wasm/generator.go
+++ b/docs/playground/wasm/generator.go
@@ -237,9 +237,9 @@ func initWebhookURL(service types.Service, webhookURL string) error {
 	}
 
 	// Call SetURL on the actual config.
-	setter, ok := configRef.Interface().(interface {
+	setter, ok := reflect.TypeAssert[interface {
 		SetURL(webhookURL *url.URL) error
-	})
+	}](configRef)
 	if !ok {
 		return errNoSetURL
 	}
@@ -287,7 +287,7 @@ func getServiceConfigFromService(service types.Service) (types.ServiceConfig, bo
 		return nil, false
 	}
 
-	svcConfig, ok := configRef.Interface().(types.ServiceConfig)
+	svcConfig, ok := reflect.TypeAssert[types.ServiceConfig](configRef)
 
 	return svcConfig, ok
 }

--- a/docs/playground/wasm/parser.go
+++ b/docs/playground/wasm/parser.go
@@ -145,7 +145,7 @@ func extractWebhookDisplay(configValue reflect.Value) string {
 		return ""
 	}
 
-	webhookURL, ok := results[0].Interface().(*url.URL)
+	webhookURL, ok := reflect.TypeAssert[*url.URL](results[0])
 	if !ok {
 		return ""
 	}

--- a/docs/playground/wasm/schema.go
+++ b/docs/playground/wasm/schema.go
@@ -134,7 +134,7 @@ func convertFields(nodes []format.Node, config types.ServiceConfig) []fieldSchem
 	for _, node := range nodes {
 		field := node.Field()
 
-		//nolint:exhaustruct // EnumValues set conditionally below.
+		//nolint:exhaustruct_v5 // EnumValues set conditionally below.
 		schema := fieldSchema{
 			Name:         field.Name,
 			Type:         classifyType(field.Type, field.IsEnum()),

--- a/pkg/format/config_props.go
+++ b/pkg/format/config_props.go
@@ -14,7 +14,7 @@ var ErrNotConfigProp = errors.New("struct field cannot be used as a prop")
 func GetConfigPropFromString(structType reflect.Type, value string) (reflect.Value, error) {
 	valuePtr := reflect.New(structType)
 
-	configProp, ok := valuePtr.Interface().(types.ConfigProp)
+	configProp, ok := reflect.TypeAssert[types.ConfigProp](valuePtr)
 	if !ok {
 		return reflect.Value{}, ErrNotConfigProp
 	}
@@ -35,7 +35,7 @@ func GetConfigPropString(propPtr reflect.Value) (string, error) {
 	}
 
 	if propPtr.CanInterface() {
-		if configProp, ok := propPtr.Interface().(types.ConfigProp); ok {
+		if configProp, ok := reflect.TypeAssert[types.ConfigProp](propPtr); ok {
 			s, err := configProp.GetPropValue()
 			if err != nil {
 				return "", fmt.Errorf("failed to get config prop string: %w", err)

--- a/pkg/format/field_info.go
+++ b/pkg/format/field_info.go
@@ -52,7 +52,7 @@ func getStructFieldInfo(structType reflect.Type, enums map[string]types.EnumForm
 			continue
 		}
 
-		//nolint:exhaustruct // Partial initialization is intentional, other fields are set below
+		//nolint:exhaustruct_v5 // Partial initialization is intentional, other fields are set below
 		info := FieldInfo{
 			Name:          fieldDef.Name,
 			Type:          fieldDef.Type,

--- a/pkg/format/formatter.go
+++ b/pkg/format/formatter.go
@@ -61,7 +61,7 @@ func GetServiceConfig(service types.Service) types.ServiceConfig {
 		panic("failed to create new config instance")
 	}
 
-	if config, ok := configRef.Interface().(types.ServiceConfig); ok {
+	if config, ok := reflect.TypeAssert[types.ServiceConfig](configRef); ok {
 		return config
 	}
 

--- a/pkg/generators/basic/basic.go
+++ b/pkg/generators/basic/basic.go
@@ -63,7 +63,7 @@ func (g *Generator) Generate(
 		return nil, err
 	}
 
-	if config, ok := configPtr.Interface().(types.ServiceConfig); ok {
+	if config, ok := reflect.TypeAssert[types.ServiceConfig](configPtr); ok {
 		return config, nil
 	}
 
@@ -172,7 +172,7 @@ func (g *Generator) promptUserForFields(
 	props map[string]string,
 	scanner *bufio.Scanner,
 ) error {
-	serviceConfig, ok := configPtr.Interface().(types.ServiceConfig)
+	serviceConfig, ok := reflect.TypeAssert[types.ServiceConfig](configPtr)
 	if !ok {
 		return ErrInvalidConfigType
 	}

--- a/pkg/services/chat/discord/discord_json.go
+++ b/pkg/services/chat/discord/discord_json.go
@@ -106,7 +106,7 @@ func processEmbedFields(
 			thumbnail = &embedThumbnail{URL: field.Value}
 		default:
 			// Regular fields become embed fields
-			//nolint:exhaustruct // Inline is optional and defaults to false
+			//nolint:exhaustruct_v5 // Inline is optional and defaults to false
 			embedFields = append(embedFields, embedField{
 				Name:  field.Key,
 				Value: field.Value,
@@ -166,7 +166,7 @@ func CreatePayloadFromItems(
 
 		author, image, thumbnail, embedFields := processEmbedFields(item.Fields)
 
-		//nolint:exhaustruct // Fields are conditionally set below
+		//nolint:exhaustruct_v5 // Fields are conditionally set below
 		embeddedItem := embedItem{
 			Content:   item.Text,
 			Color:     color,
@@ -177,7 +177,7 @@ func CreatePayloadFromItems(
 		}
 
 		if item.Level != types.Unknown {
-			//nolint:exhaustruct // IconURL is optional
+			//nolint:exhaustruct_v5 // IconURL is optional
 			embeddedItem.Footer = &embedFooter{
 				Text: item.Level.String(),
 			}

--- a/pkg/services/chat/lark/lark_service.go
+++ b/pkg/services/chat/lark/lark_service.go
@@ -149,7 +149,7 @@ func (s *Service) getRequestBody(
 		body.Content.Text = message
 	} else {
 		body.MsgType = MsgTypePost
-		//nolint:exhaustruct // Item fields are populated inline; Link is optional
+		//nolint:exhaustruct_v5 // Item fields are populated inline; Link is optional
 		content := [][]Item{{{Tag: TagValueTextContent, Text: message}}}
 
 		if params != nil {
@@ -162,7 +162,7 @@ func (s *Service) getRequestBody(
 			}
 		}
 
-		//nolint:exhaustruct // Post fields are populated inline; Zh is optional
+		//nolint:exhaustruct_v5 // Post fields are populated inline; Zh is optional
 		body.Content.Post = &Post{
 			En: &Message{
 				Title:   title,

--- a/pkg/services/chat/matrix/matrix_client.go
+++ b/pkg/services/chat/matrix/matrix_client.go
@@ -321,7 +321,7 @@ func (c *client) loginPassword(ctx context.Context, user, password string) error
 	deviceID := generateDeviceID(user, c.apiURL.Host)
 	c.logf("Using device ID: %v\n", deviceID)
 
-	//nolint:exhaustruct // Intentional zero-value initialization for apiReqLogin
+	//nolint:exhaustruct_v5 // Intentional zero-value initialization for apiReqLogin
 	err := c.apiPost(
 		ctx,
 		apiLogin,
@@ -361,7 +361,7 @@ func (c *client) loginToken(ctx context.Context, token string) error {
 	deviceID := generateDeviceID("", c.apiURL.Host)
 	c.logf("Using device ID: %v\n", deviceID)
 
-	//nolint:exhaustruct // Intentional zero-value initialization for apiReqLogin
+	//nolint:exhaustruct_v5 // Intentional zero-value initialization for apiReqLogin
 	err := c.apiPost(
 		ctx,
 		apiLogin,
@@ -580,7 +580,7 @@ func normalizeHostForDeviceID(host string) string {
 
 // newClient creates a new Matrix client with the specified host and TLS settings.
 //
-//nolint:exhaustruct // Intentional partial initialization
+//nolint:exhaustruct_v5 // Intentional partial initialization
 func newClient(host string, disableTLS bool, logger types.StdLogger) *client {
 	client := &client{
 		logger: logger,

--- a/pkg/services/chat/teams/teams_service.go
+++ b/pkg/services/chat/teams/teams_service.go
@@ -138,7 +138,7 @@ func (s *Service) doSend(config *Config, message string) error {
 	body := make([]adaptiveBlock, 0, len(lines)+1)
 
 	if config.Title != "" {
-		//nolint:exhaustruct // Color, Wrap are optional and set conditionally
+		//nolint:exhaustruct_v5 // Color, Wrap are optional and set conditionally
 		titleBlock := adaptiveBlock{
 			Type:   "TextBlock",
 			Text:   config.Title,
@@ -155,7 +155,7 @@ func (s *Service) doSend(config *Config, message string) error {
 			continue
 		}
 
-		//nolint:exhaustruct // Color, Weight, Size are optional and default to zero values
+		//nolint:exhaustruct_v5 // Color, Weight, Size are optional and default to zero values
 		body = append(body, adaptiveBlock{
 			Type: "TextBlock",
 			Text: line,

--- a/pkg/services/chat/telegram/telegram_parsemode.go
+++ b/pkg/services/chat/telegram/telegram_parsemode.go
@@ -34,7 +34,8 @@ var ParseModes = &parseModeVals{
 			"Markdown",
 			"HTML",
 			"MarkdownV2",
-		}),
+		},
+	),
 }
 
 func (pm parseMode) String() string {

--- a/pkg/services/email/smtp/smtp_authtype.go
+++ b/pkg/services/email/smtp/smtp_authtype.go
@@ -42,7 +42,8 @@ var AuthTypes = &authTypeVals{
 			"Unknown",
 			"OAuth2",
 			"Login",
-		}),
+		},
+	),
 }
 
 func (at authType) String() string {

--- a/pkg/services/email/smtp/smtp_encmethod.go
+++ b/pkg/services/email/smtp/smtp_encmethod.go
@@ -48,7 +48,8 @@ var EncMethods = &encMethodVals{
 			"ExplicitTLS",
 			"ImplicitTLS",
 			"Auto",
-		}),
+		},
+	),
 }
 
 func (at encMethod) String() string {

--- a/pkg/services/incident/pagerduty/pagerduty.go
+++ b/pkg/services/incident/pagerduty/pagerduty.go
@@ -327,11 +327,11 @@ func parseContexts(contextsStr string) ([]PagerDutyContext, error) {
 		switch contextType {
 		case "link":
 			// Create a link context with href
-			//nolint:exhaustruct // link type only needs Type+Href
+			//nolint:exhaustruct_v5 // link type only needs Type+Href
 			ctxVar = PagerDutyContext{Type: "link", Href: value}
 		case "image":
 			// Create an image context with src
-			//nolint:exhaustruct // image type only needs Type+Src
+			//nolint:exhaustruct_v5 // image type only needs Type+Src
 			ctxVar = PagerDutyContext{Type: "image", Src: value}
 		case "text":
 			// Skip text contexts

--- a/pkg/services/push/mqtt/mqtt_config.go
+++ b/pkg/services/push/mqtt/mqtt_config.go
@@ -148,7 +148,8 @@ var QoSValues = &qosVals{
 			"at_most_once":  int(QoSAtMostOnce),
 			"at_least_once": int(QoSAtLeastOnce),
 			"exactly_once":  int(QoSExactlyOnce),
-		}),
+		},
+	),
 }
 
 // Enums returns a map of enum type names to their formatters.

--- a/pkg/services/push/mqtt/mqtt_service.go
+++ b/pkg/services/push/mqtt/mqtt_service.go
@@ -215,7 +215,7 @@ func (s *Service) Send(message string, params *types.Params) error {
 	}
 
 	// Publish the message to the configured topic with QoS and retention settings
-	//nolint:exhaustruct // paho.Publish PacketID is auto-generated, Properties optional for MQTT v5
+	//nolint:exhaustruct_v5 // paho.Publish PacketID is auto-generated, Properties optional for MQTT v5
 	resp, err := s.connectionManager.Publish(
 		ctx,
 		&paho.Publish{
@@ -420,13 +420,13 @@ func (s *Service) initClient() error {
 	ctx := s.ctx
 
 	// Create autopaho client configuration
-	//nolint:exhaustruct // autopaho.ClientConfig has many optional fields with library defaults
+	//nolint:exhaustruct_v5 // autopaho.ClientConfig has many optional fields with library defaults
 	cliCfg := autopaho.ClientConfig{
 		ServerUrls:                    []*url.URL{serverURL},
 		KeepAlive:                     keepAliveInterval,
 		CleanStartOnInitialConnection: s.Config.CleanSession,
 		SessionExpiryInterval:         sessionExpiryInterval,
-		ClientConfig: paho.ClientConfig{
+		ClientConfig: paho.ClientConfig{ //nolint:exhaustruct_v5 // remaining fields use library defaults
 			ClientID: s.Config.ClientID,
 			OnServerDisconnect: func(disconnect *paho.Disconnect) {
 				s.Logf("Server disconnected: reason code %d", disconnect.ReasonCode)

--- a/pkg/services/push/ntfy/ntfy_priority.go
+++ b/pkg/services/push/ntfy/ntfy_priority.go
@@ -47,7 +47,8 @@ var Priority = &priorityVals{
 			"4":      int(PriorityHigh),
 			"5":      int(PriorityMax),
 			"urgent": int(PriorityMax),
-		}),
+		},
+	),
 }
 
 func (p priority) String() string {

--- a/pkg/services/push/pushbullet/pushbullet_json.go
+++ b/pkg/services/push/pushbullet/pushbullet_json.go
@@ -49,7 +49,7 @@ func (err *ResponseError) Error() string {
 
 // NewNotePush creates a new push request.
 //
-//nolint:exhaustruct // PushRequest targeting fields (Email, ChannelTag, DeviceIden) are set by SetTarget method
+//nolint:exhaustruct_v5 // PushRequest targeting fields (Email, ChannelTag, DeviceIden) are set by SetTarget method
 func NewNotePush(message, title string) *PushRequest {
 	return &PushRequest{
 		Type:  "note",

--- a/pkg/util/message.go
+++ b/pkg/util/message.go
@@ -64,7 +64,7 @@ func PartitionMessage(
 			}
 		}
 
-		//nolint:exhaustruct // MessageItem only requires Text field for this use case
+		//nolint:exhaustruct_v5 // MessageItem only requires Text field for this use case
 		items = append(items, types.MessageItem{
 			Text: string(runes[chunkOffset:chunkEnd]),
 		})
@@ -136,7 +136,7 @@ func MessageItemsFromLines(plain string, limits types.MessageLimit) [][]types.Me
 			continue
 		}
 
-		//nolint:exhaustruct // MessageItem only requires Text field for this use case
+		//nolint:exhaustruct_v5 // MessageItem only requires Text field for this use case
 		items = append(items, types.MessageItem{
 			Text: line,
 		})


### PR DESCRIPTION
This PR updates the lint configuration for current golangci-lint linters and applies the resulting code updates.

## Problem

The enabled `exhaustruct` linter is deprecated in favor of `exhaustruct_v5`, and the `gofumpt` `extra-rules` option has been replaced by explicit extra settings.

## Solution

Switch to `exhaustruct_v5` with the existing ignore list, and apply the current `gofumpt` extra options and `reflect.TypeAssert` conversions.

## Changes

- Enable `exhaustruct_v5` and disable the deprecated `exhaustruct` linter.
- Configure `gofumpt` extra options for grouped params, clothed returns, and balanced calls.
- Replace `reflect.Value.Interface` type assertions with `reflect.TypeAssert`.