### PR TITLE
fix(smtp): stop wrapping raw html bodies in <pre> tags

### DIFF
--- a/pkg/services/email/smtp/smtp.go
+++ b/pkg/services/email/smtp/smtp.go
@@ -359,12 +359,7 @@ func (s *Service) writeMessagePart(
 			return fail(FailMessageTemplate, err)
 		}
 	} else {
-		content := message
-		if template == "HTML" {
-			content = fmt.Sprintf("<pre>%s</pre>", message)
-		}
-
-		if _, err := fmt.Fprint(writeCloser, content); err != nil {
+		if _, err := fmt.Fprint(writeCloser, message); err != nil {
 			return fail(FailMessageRaw, err)
 		}
 	}

--- a/pkg/services/email/smtp/smtp_test.go
+++ b/pkg/services/email/smtp/smtp_test.go
@@ -33,6 +33,11 @@ type mockConn struct {
 	closeCount int
 }
 
+// captureWriter records writes for writeMessagePart tests.
+type captureWriter struct {
+	bytes.Buffer
+}
+
 var tt *testing.T
 
 var (
@@ -305,6 +310,23 @@ var _ = ginkgo.Describe("the SMTP service", func() {
 			err := service.writeMessagePart(writer, message, "dummy")
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err).To(matchFailure(FailMessageTemplate))
+		})
+	})
+
+	ginkgo.When("writing a message part without a template", func() {
+		ginkgo.It("should write the HTML body as-is without wrapping in pre", func() {
+			service := Service{}
+			writer := &captureWriter{}
+			err := service.writeMessagePart(writer, "<p>styled</p>", "HTML")
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(writer.String()).To(gomega.Equal("<p>styled</p>"))
+		})
+		ginkgo.It("should write the plain body as-is", func() {
+			service := Service{}
+			writer := &captureWriter{}
+			err := service.writeMessagePart(writer, "plain text", "plain")
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(writer.String()).To(gomega.Equal("plain text"))
 		})
 	})
 
@@ -808,6 +830,10 @@ var _ = ginkgo.Describe("the SMTP service", func() {
 		gomega.Expect(service.GetID()).To(gomega.Equal("smtp"))
 	})
 })
+
+func (c *captureWriter) Close() error {
+	return nil
+}
 
 func (m *mockConn) Close() error {
 	m.closeCount++


### PR DESCRIPTION
This PR stops wrapping SMTP HTML notification bodies in `<pre>` tags. Styled HTML is now sent as written when `useHTML=yes` and no library template is set.

## Problem

Untemplated HTML parts were wrapped in `<pre>`, which forced monospace rendering and broke CSS font styling.

## Solution

Send the HTML part as-is when no library template is set.

## Changes

- Write untemplated HTML message parts without a `<pre>` wrapper
- Cover HTML and plain `writeMessagePart` paths without templates