### PR TITLE
docs(smtp): document configuration options and examples

### DIFF
--- a/docs/services/email/smtp/index.md
+++ b/docs/services/email/smtp/index.md
@@ -19,7 +19,7 @@ A `Username` and `Password` are required only when the server expects authentica
 !!! Example "Minimal authenticated send"
 
     ```uri
-    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com
+    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com&requirestarttls=yes
     ```
 
     Connects to `mail.example.com` on port 587, authenticates as `user`, and sends to `ops@example.com`.
@@ -41,7 +41,7 @@ Common ports:
 !!! Example "Submission on 587"
 
     ```uri
-    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com
+    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com&requirestarttls=yes
     ```
 
 ### Username and Password
@@ -65,7 +65,7 @@ Common ports:
 !!! Example "Named sender"
 
     ```uri
-    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&fromname=Shoutrrr&toaddresses=ops@example.com
+    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&fromname=Shoutrrr&toaddresses=ops@example.com&requirestarttls=yes
     ```
 
 ### Recipients
@@ -76,13 +76,13 @@ Common ports:
 !!! Example "Multiple recipients"
 
     ```uri
-    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com,oncall@example.com
+    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com,oncall@example.com&requirestarttls=yes
     ```
 
 !!! Example "Plus-address recipient"
 
     ```uri
-    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops+prod@example.com
+    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops+prod@example.com&requirestarttls=yes
     ```
 
 ### Subject
@@ -93,7 +93,7 @@ Common ports:
 !!! Example "Custom subject"
 
     ```uri
-    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com&subject=Disk%20space%20low
+    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com&subject=Disk%20space%20low&requirestarttls=yes
     ```
 
 ### Authentication
@@ -112,7 +112,7 @@ Common ports:
 !!! Example "AUTH LOGIN"
 
     ```uri
-    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com&auth=Login
+    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com&auth=Login&requirestarttls=yes
     ```
 
 !!! Example "OAuth2 access token"
@@ -130,12 +130,12 @@ Common ports:
 - `usestarttls` defaults to yes and is independent of `encryption`.
 - `encryption=None` still attempts STARTTLS unless you also set `usestarttls=no`.
 
-| Value         | Behavior                                                                     |
-|---------------|------------------------------------------------------------------------------|
-| `None`        | No implicit TLS; STARTTLS is still attempted unless `usestarttls=no`         |
-| `ExplicitTLS` | STARTTLS after connect                                                       |
-| `ImplicitTLS` | TLS from the first byte (typical for port 465)                               |
-| `Auto`        | Implicit TLS on port 465; otherwise explicit TLS when the server supports it |
+| Value         | Behavior                                                                                             |
+|---------------|------------------------------------------------------------------------------------------------------|
+| `None`        | No implicit TLS; STARTTLS is still attempted unless `usestarttls=no`                                 |
+| `ExplicitTLS` | STARTTLS after connect when `usestarttls` is enabled; with `usestarttls=no` the session is plaintext |
+| `ImplicitTLS` | TLS from the first byte (typical for port 465)                                                       |
+| `Auto`        | Implicit TLS on port 465; otherwise STARTTLS when `usestarttls` is enabled                           |
 
 !!! Example "Implicit TLS on 465"
 
@@ -177,7 +177,7 @@ Common ports:
 !!! Example "Skip verify on an internal relay"
 
     ```uri
-    smtp://user:pass@mail.internal:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com&skiptlsverify=yes
+    smtp://user:pass@mail.internal:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com&skiptlsverify=yes&requirestarttls=yes
     ```
 
 ### HTML Body
@@ -190,7 +190,7 @@ Common ports:
 !!! Example "HTML notification"
 
     ```uri
-    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com&usehtml=yes
+    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com&usehtml=yes&requirestarttls=yes
     ```
 
     Pass HTML as the message body, for example `<p>Disk usage is <strong>92%</strong>.</p>`.
@@ -204,7 +204,7 @@ Common ports:
 !!! Example "Auto client host"
 
     ```uri
-    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com&clienthost=auto
+    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com&clienthost=auto&requirestarttls=yes
     ```
 
 ### Timeout
@@ -216,7 +216,7 @@ Common ports:
 !!! Example "Thirty-second timeout"
 
     ```uri
-    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com&timeout=30s
+    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com&timeout=30s&requirestarttls=yes
     ```
 
 ## Message Templates
@@ -243,7 +243,7 @@ Common ports:
 !!! Example "STARTTLS on port 587"
 
     ```uri
-    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com
+    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com&requirestarttls=yes
     ```
 
 !!! Example "Implicit TLS on port 465"
@@ -255,13 +255,13 @@ Common ports:
 !!! Example "HTML body"
 
     ```uri
-    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com&usehtml=yes&subject=Alert
+    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com&usehtml=yes&subject=Alert&requirestarttls=yes
     ```
 
 !!! Example "Plus-address recipient"
 
     ```uri
-    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops+prod@example.com
+    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops+prod@example.com&requirestarttls=yes
     ```
 
 !!! Example "Unauthenticated local relay"

--- a/docs/services/email/smtp/index.md
+++ b/docs/services/email/smtp/index.md
@@ -1,6 +1,7 @@
 # Email
 
-Shoutrrr can send notifications as email over SMTP. It talks to any RFC 5321 server (Gmail, Microsoft 365, self-hosted Postfix, and similar) using a single service URL.
+Shoutrrr can send notifications as email over SMTP.
+It talks to any RFC 5321 server (Gmail, Microsoft 365, self-hosted Postfix, and similar) using a single service URL.
 
 ## URL Format
 
@@ -27,7 +28,10 @@ A `Username` and `Password` are required only when the server expects authentica
 
 ### Host and Port
 
-`Host` is the SMTP server hostname or IP address and is required. `Port` defaults to `25`. Common ports:
+- `Host` is the SMTP server hostname or IP address and is required.
+- `Port` defaults to `25`.
+
+Common ports:
 
 - __25__: traditional SMTP (often blocked on residential networks)
 - __587__: submission with STARTTLS
@@ -42,7 +46,10 @@ A `Username` and `Password` are required only when the server expects authentica
 
 ### Username and Password
 
-`Username` and `Password` are the SMTP credentials. Both default to empty. Leave them empty for servers that allow unauthenticated relay. For `auth=OAuth2`, put the access token in the password field.
+- `Username` and `Password` are the SMTP credentials.
+- Both default to empty.
+- Leave them empty for servers that allow unauthenticated relay.
+- For `auth=OAuth2`, put the access token in the password field.
 
 !!! Example "No credentials"
 
@@ -52,7 +59,8 @@ A `Username` and `Password` are required only when the server expects authentica
 
 ### From Address and From Name
 
-`fromaddress` (alias `from`) is the envelope and header From address and is required. `fromname` is an optional display name shown by mail clients.
+- `fromaddress` (alias `from`) is the envelope and header From address and is required.
+- `fromname` is an optional display name shown by mail clients.
 
 !!! Example "Named sender"
 
@@ -62,7 +70,8 @@ A `Username` and `Password` are required only when the server expects authentica
 
 ### Recipients
 
-`toaddresses` (alias `to`) is a comma-separated list of recipient addresses and is required. Plus-tags in addresses (`user+tag@example.com`) are preserved; spaces that come from URL-decoding `+` are turned back into `+`.
+- `toaddresses` (alias `to`) is a comma-separated list of recipient addresses and is required.
+- Plus-tags in addresses (`user+tag@example.com`) are preserved and spaces that come from URL-decoding `+` are turned back into `+`.
 
 !!! Example "Multiple recipients"
 
@@ -78,7 +87,8 @@ A `Username` and `Password` are required only when the server expects authentica
 
 ### Subject
 
-`subject` (alias `title`) is the email subject. Default: `Shoutrrr Notification`.
+- `subject` (alias `title`) is the email subject.
+- When the URL omits `subject`, the header is empty.
 
 !!! Example "Custom subject"
 
@@ -108,18 +118,21 @@ A `Username` and `Password` are required only when the server expects authentica
 !!! Example "OAuth2 access token"
 
     ```uri
-    smtp://user:ya29.token@smtp.gmail.com:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com&auth=OAuth2
+    smtp://user:ya29.token@smtp.gmail.com:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com&auth=OAuth2&requirestarttls=yes
     ```
 
-    The token is not refreshed. Supply a current access token for each send.
+    The token is not refreshed.
+    Supply a current access token for each send.
 
 ### Encryption
 
-`encryption` selects how TLS is applied. Default: `Auto`.
+- `encryption` selects how TLS is applied. Default: `Auto`.
+- `usestarttls` defaults to yes and is independent of `encryption`.
+- `encryption=None` still attempts STARTTLS unless you also set `usestarttls=no`.
 
 | Value         | Behavior                                                                     |
 |---------------|------------------------------------------------------------------------------|
-| `None`        | No TLS                                                                       |
+| `None`        | No implicit TLS; STARTTLS is still attempted unless `usestarttls=no`         |
 | `ExplicitTLS` | STARTTLS after connect                                                       |
 | `ImplicitTLS` | TLS from the first byte (typical for port 465)                               |
 | `Auto`        | Implicit TLS on port 465; otherwise explicit TLS when the server supports it |
@@ -132,7 +145,8 @@ A `Username` and `Password` are required only when the server expects authentica
 
 ### StartTLS
 
-`usestarttls` (alias `starttls`) defaults to yes. When enabled and the server does not advertise STARTTLS, Shoutrrr logs a warning and continues unencrypted unless `requirestarttls` is set.
+- `usestarttls` (alias `starttls`) defaults to yes.
+- When enabled and the server does not advertise STARTTLS, Shoutrrr logs a warning and continues unencrypted unless `requirestarttls` is set.
 
 !!! Example "Disable STARTTLS"
 
@@ -142,7 +156,8 @@ A `Username` and `Password` are required only when the server expects authentica
 
 ### Require StartTLS
 
-`requirestarttls` defaults to no. When yes, send fails if STARTTLS is enabled but the server does not support it.
+- `requirestarttls` defaults to no.
+- When yes, send fails if STARTTLS is enabled but the server does not support it.
 
 !!! Example "Fail closed without STARTTLS"
 
@@ -152,10 +167,12 @@ A `Username` and `Password` are required only when the server expects authentica
 
 ### Skip TLS Certificate Verification
 
-`skiptlsverify` defaults to no. When TLS is negotiated, `yes` disables server certificate verification; however, it does not enable TLS.
+- `skiptlsverify` defaults to no.
+- When TLS is negotiated, `yes` disables server certificate verification; however, it does not enable TLS.
 
 !!! danger "Security Risk"
-    Skipping certificate verification makes the connection vulnerable to man-in-the-middle attacks. Only use this on networks you trust, such as a lab or an internal mail relay with a private CA.
+    Skipping certificate verification makes the connection vulnerable to man-in-the-middle attacks.
+    Only use this on networks you trust, such as a lab or an internal mail relay with a private CA.
 
 !!! Example "Skip verify on an internal relay"
 
@@ -165,7 +182,10 @@ A `Username` and `Password` are required only when the server expects authentica
 
 ### HTML Body
 
-`usehtml` defaults to no. When yes, the message is sent as `multipart/alternative` with a `text/plain` part and a `text/html` part. The same message string is used for both parts. The HTML part is sent __as-is__ (not wrapped in `<pre>`).
+- `usehtml` defaults to no.
+- When yes, the message is sent as `multipart/alternative` with a `text/plain` part and a `text/html` part.
+- The same message string is used for both parts.
+- The HTML part is sent __as-is__.
 
 !!! Example "HTML notification"
 
@@ -177,7 +197,9 @@ A `Username` and `Password` are required only when the server expects authentica
 
 ### Client Host
 
-`clienthost` is the hostname sent in the SMTP `EHLO`/`HELO` handshake. Default: `localhost`. Set it to `auto` to use the operating system hostname (falling back to `localhost` if lookup fails).
+- `clienthost` is the hostname sent in the SMTP `EHLO`/`HELO` handshake.
+- Default: `localhost`.
+- Set it to `auto` to use the operating system hostname (falling back to `localhost` if lookup fails).
 
 !!! Example "Auto client host"
 
@@ -187,7 +209,9 @@ A `Username` and `Password` are required only when the server expects authentica
 
 ### Timeout
 
-`timeout` is a Go duration for SMTP operations. Default: `10s`.
+- `timeout` is a Go duration applied when establishing the SMTP connection.
+- Default: `10s`.
+- Later commands (EHLO, AUTH, DATA) are not covered by this deadline.
 
 !!! Example "Thirty-second timeout"
 
@@ -197,19 +221,22 @@ A `Username` and `Password` are required only when the server expects authentica
 
 ## Message Templates
 
-SMTP templates are a __Go library API only__. They are not URL or CLI parameters.
+- SMTP templates are only available via the __Shoutrrr API__.
+- They are not URL or CLI parameters.
+- IDs are `"plain"` and `"HTML"`.
+- The template data map has a `message` key.
 
-IDs are `"plain"` and `"HTML"`. The template data map has a `message` key.
+!!! Example "`<div>`-wrapped message body"
 
-```go
-err := service.SetTemplateString("HTML", `<div>{{ .message }}</div>`)
-```
+    ```go
+    err := service.SetTemplateString("HTML", `<div>{{ .message }}</div>`)
+    ```
 
-If you want a `<pre>` wrapper around an HTML part, include it in the message or set an `"HTML"` template:
+!!! Example "If you want a `<pre>` wrapper around an HTML part, include it in the message or set an `"HTML"` template"
 
-```go
-err := service.SetTemplateString("HTML", `<pre>{{ .message }}</pre>`)
-```
+    ```go
+    err := service.SetTemplateString("HTML", `<pre>{{ .message }}</pre>`)
+    ```
 
 ## Examples
 

--- a/docs/services/email/smtp/index.md
+++ b/docs/services/email/smtp/index.md
@@ -1,8 +1,244 @@
 # Email
 
+Shoutrrr can send notifications as email over SMTP. It talks to any RFC 5321 server (Gmail, Microsoft 365, self-hosted Postfix, and similar) using a single service URL.
+
 ## URL Format
 
 !!! info ""
     smtp://__`username`__:__`password`__@__`host`__:__`port`__/?fromaddress=__`fromAddress`__&toaddresses=__`recipient1`__[,__`recipient2`__,...]&subject=__`subject`__&auth=__`auth`__&encryption=__`encryption`__&useStartTLS=__`yes/no`__&useHTML=__`yes/no`__&clientHost=__`hostname`__&requirestarttls=__`yes/no`__&skiptlsverify=__`yes/no`__&timeout=__`duration`__
 
 --8<-- "docs/services/email/smtp/config.md"
+
+## Getting Started
+
+Every SMTP URL needs a `host`, a `fromaddress`, and at least one `toaddresses` recipient.
+
+A `Username` and `Password` are required only when the server expects authentication.
+
+!!! Example "Minimal authenticated send"
+
+    ```uri
+    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com
+    ```
+
+    Connects to `mail.example.com` on port 587, authenticates as `user`, and sends to `ops@example.com`.
+
+## Configuration Parameters
+
+### Host and Port
+
+`Host` is the SMTP server hostname or IP address and is required. `Port` defaults to `25`. Common ports:
+
+- __25__: traditional SMTP (often blocked on residential networks)
+- __587__: submission with STARTTLS
+- __465__: implicit TLS (SMTPS)
+- __2525__: alternate submission port used by some providers
+
+!!! Example "Submission on 587"
+
+    ```uri
+    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com
+    ```
+
+### Username and Password
+
+`Username` and `Password` are the SMTP credentials. Both default to empty. Leave them empty for servers that allow unauthenticated relay. For `auth=OAuth2`, put the access token in the password field.
+
+!!! Example "No credentials"
+
+    ```uri
+    smtp://mail.example.com:25/?fromaddress=alerts@example.com&toaddresses=ops@example.com&auth=None
+    ```
+
+### From Address and From Name
+
+`fromaddress` (alias `from`) is the envelope and header From address and is required. `fromname` is an optional display name shown by mail clients.
+
+!!! Example "Named sender"
+
+    ```uri
+    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&fromname=Shoutrrr&toaddresses=ops@example.com
+    ```
+
+### Recipients
+
+`toaddresses` (alias `to`) is a comma-separated list of recipient addresses and is required. Plus-tags in addresses (`user+tag@example.com`) are preserved; spaces that come from URL-decoding `+` are turned back into `+`.
+
+!!! Example "Multiple recipients"
+
+    ```uri
+    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com,oncall@example.com
+    ```
+
+!!! Example "Plus-address recipient"
+
+    ```uri
+    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops+prod@example.com
+    ```
+
+### Subject
+
+`subject` (alias `title`) is the email subject. Default: `Shoutrrr Notification`.
+
+!!! Example "Custom subject"
+
+    ```uri
+    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com&subject=Disk%20space%20low
+    ```
+
+### Authentication
+
+`auth` selects the SMTP AUTH method. Default: `Unknown`.
+
+| Value     | Behavior                                                                       |
+|-----------|--------------------------------------------------------------------------------|
+| `None`    | No AUTH                                                                        |
+| `Plain`   | AUTH PLAIN (username and password)                                             |
+| `Login`   | AUTH LOGIN, for servers that do not support PLAIN                              |
+| `CRAMMD5` | AUTH CRAM-MD5                                                                  |
+| `OAuth2`  | SASL XOAUTH2 with a __static__ access token in the password field (no refresh) |
+| `Unknown` | If a username is set, treated as `Plain`; otherwise `None`                     |
+
+!!! Example "AUTH LOGIN"
+
+    ```uri
+    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com&auth=Login
+    ```
+
+!!! Example "OAuth2 access token"
+
+    ```uri
+    smtp://user:ya29.token@smtp.gmail.com:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com&auth=OAuth2
+    ```
+
+    The token is not refreshed. Supply a current access token for each send.
+
+### Encryption
+
+`encryption` selects how TLS is applied. Default: `Auto`.
+
+| Value         | Behavior                                                                     |
+|---------------|------------------------------------------------------------------------------|
+| `None`        | No TLS                                                                       |
+| `ExplicitTLS` | STARTTLS after connect                                                       |
+| `ImplicitTLS` | TLS from the first byte (typical for port 465)                               |
+| `Auto`        | Implicit TLS on port 465; otherwise explicit TLS when the server supports it |
+
+!!! Example "Implicit TLS on 465"
+
+    ```uri
+    smtp://user:pass@mail.example.com:465/?fromaddress=alerts@example.com&toaddresses=ops@example.com&encryption=ImplicitTLS
+    ```
+
+### StartTLS
+
+`usestarttls` (alias `starttls`) defaults to yes. When enabled and the server does not advertise STARTTLS, Shoutrrr logs a warning and continues unencrypted unless `requirestarttls` is set.
+
+!!! Example "Disable STARTTLS"
+
+    ```uri
+    smtp://user:pass@mail.example.com:25/?fromaddress=alerts@example.com&toaddresses=ops@example.com&usestarttls=no
+    ```
+
+### Require StartTLS
+
+`requirestarttls` defaults to no. When yes, send fails if STARTTLS is enabled but the server does not support it.
+
+!!! Example "Fail closed without STARTTLS"
+
+    ```uri
+    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com&requirestarttls=yes
+    ```
+
+### Skip TLS Certificate Verification
+
+`skiptlsverify` defaults to no. When TLS is negotiated, `yes` disables server certificate verification; however, it does not enable TLS.
+
+!!! danger "Security Risk"
+    Skipping certificate verification makes the connection vulnerable to man-in-the-middle attacks. Only use this on networks you trust, such as a lab or an internal mail relay with a private CA.
+
+!!! Example "Skip verify on an internal relay"
+
+    ```uri
+    smtp://user:pass@mail.internal:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com&skiptlsverify=yes
+    ```
+
+### HTML Body
+
+`usehtml` defaults to no. When yes, the message is sent as `multipart/alternative` with a `text/plain` part and a `text/html` part. The same message string is used for both parts. The HTML part is sent __as-is__ (not wrapped in `<pre>`).
+
+!!! Example "HTML notification"
+
+    ```uri
+    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com&usehtml=yes
+    ```
+
+    Pass HTML as the message body, for example `<p>Disk usage is <strong>92%</strong>.</p>`.
+
+### Client Host
+
+`clienthost` is the hostname sent in the SMTP `EHLO`/`HELO` handshake. Default: `localhost`. Set it to `auto` to use the operating system hostname (falling back to `localhost` if lookup fails).
+
+!!! Example "Auto client host"
+
+    ```uri
+    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com&clienthost=auto
+    ```
+
+### Timeout
+
+`timeout` is a Go duration for SMTP operations. Default: `10s`.
+
+!!! Example "Thirty-second timeout"
+
+    ```uri
+    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com&timeout=30s
+    ```
+
+## Message Templates
+
+SMTP templates are a __Go library API only__. They are not URL or CLI parameters.
+
+IDs are `"plain"` and `"HTML"`. The template data map has a `message` key.
+
+```go
+err := service.SetTemplateString("HTML", `<div>{{ .message }}</div>`)
+```
+
+If you want a `<pre>` wrapper around an HTML part, include it in the message or set an `"HTML"` template:
+
+```go
+err := service.SetTemplateString("HTML", `<pre>{{ .message }}</pre>`)
+```
+
+## Examples
+
+!!! Example "STARTTLS on port 587"
+
+    ```uri
+    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com
+    ```
+
+!!! Example "Implicit TLS on port 465"
+
+    ```uri
+    smtp://user:pass@mail.example.com:465/?fromaddress=alerts@example.com&toaddresses=ops@example.com&encryption=ImplicitTLS
+    ```
+
+!!! Example "HTML body"
+
+    ```uri
+    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops@example.com&usehtml=yes&subject=Alert
+    ```
+
+!!! Example "Plus-address recipient"
+
+    ```uri
+    smtp://user:pass@mail.example.com:587/?fromaddress=alerts@example.com&toaddresses=ops+prod@example.com
+    ```
+
+!!! Example "Unauthenticated local relay"
+
+    ```uri
+    smtp://127.0.0.1:25/?fromaddress=alerts@example.com&toaddresses=ops@example.com&auth=None&usestarttls=no
+    ```

--- a/pkg/services/email/smtp/doc.go
+++ b/pkg/services/email/smtp/doc.go
@@ -107,9 +107,9 @@
 //
 // # Notes
 //
-// - The package uses the standard Go `net/smtp` library for SMTP operations.
-// - It supports multipart email messages (plain text and HTML) using a randomly generated boundary.
-// - The [Service] struct implements the shoutrrr [standard.Standard] and [standard.Templater] interfaces for logging and message templating.
-// - The package handles plus signs (`+`) in email addresses correctly, replacing spaces with plus signs as needed (see [Config.FixEmailTags]).
-// - For OAuth2 authentication, the [OAuth2Auth] function implements the SASL XOAUTH2 protocol, suitable for services like Gmail.
+//   - The package uses the standard Go `net/smtp` library for SMTP operations.
+//   - It supports multipart email messages (plain text and HTML) using a randomly generated boundary.
+//   - The [Service] struct implements the shoutrrr [standard.Standard] and [standard.Templater] interfaces for logging and message templating.
+//   - The package handles plus signs (`+`) in email addresses correctly, replacing spaces with plus signs as needed (see [Config.FixEmailTags]).
+//   - For OAuth2 authentication, the [OAuth2Auth] function implements the SASL XOAUTH2 protocol, suitable for services like Gmail.
 package smtp


### PR DESCRIPTION
This PR documents SMTP URL options with examples so users can configure auth, TLS, HTML, and related settings without reading the source.

## Problem

SMTP docs were only a URL format line plus a generated field list, with no examples or option behavior.

## Solution

Added a full SMTP guide covering each configuration option and common send URLs.

## Changes

- Document SMTP configuration options with examples in the service guide