### PR TITLE
fix(format): parse and render time.Duration fields as durations

### DIFF
--- a/docs/playground/wasm/generator.go
+++ b/docs/playground/wasm/generator.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"reflect"
 	"strings"
-	"time"
 
 	"github.com/nicholas-fedor/shoutrrr/pkg/format"
 	"github.com/nicholas-fedor/shoutrrr/pkg/router"
@@ -21,9 +20,6 @@ var errNoConfigField = errors.New("service has no Config field")
 
 // errNoSetURL is returned when a config does not support SetURL.
 var errNoSetURL = errors.New("config does not support SetURL")
-
-// errCannotSetDurationField is returned when a duration field cannot be set.
-var errCannotSetDurationField = errors.New("cannot set duration field")
 
 // generateURLString builds a Shoutrrr URL from serviceName and configJSON.
 // The configJSON is a JSON object mapping field names to string values.
@@ -47,28 +43,17 @@ func generateURLString(serviceName, configJSON string) string {
 	pkr := format.NewPropKeyResolver(config)
 	configValue := reflect.Indirect(reflect.ValueOf(config))
 	configSchema := format.GetConfigFormat(config)
-	durationType := reflect.TypeFor[time.Duration]()
 
-	// Apply defaults manually to handle duration fields correctly.
-	// PropKeyResolver.Set() can't parse duration strings like "10s" as integers,
-	// so we detect duration fields and parse them with time.ParseDuration instead.
+	// Apply defaults.
 	for _, node := range configSchema.Items {
 		field := node.Field()
 		if field.DefaultValue == "" {
 			continue
 		}
 
-		if field.Type == durationType {
-			// Parse duration defaults directly.
-			if dur, err := time.ParseDuration(field.DefaultValue); err == nil {
-				configValue.FieldByName(field.Name).SetInt(int64(dur))
-			}
-		} else {
-			// Apply non-duration defaults via PropKeyResolver.
-			for _, key := range field.Keys {
-				if err := pkr.Set(key, field.DefaultValue); err != nil {
-					return marshalError(fmt.Errorf("invalid default for %q: %w", key, err))
-				}
+		for _, key := range field.Keys {
+			if err := pkr.Set(key, field.DefaultValue); err != nil {
+				return marshalError(fmt.Errorf("invalid default for %q: %w", key, err))
 			}
 		}
 	}
@@ -110,15 +95,9 @@ func generateURLString(serviceName, configJSON string) string {
 					continue
 				}
 
-				if field.Type == durationType {
-					if dur, err := time.ParseDuration(field.DefaultValue); err == nil {
-						fieldVal.SetInt(int64(dur))
-					}
-				} else {
-					for _, key := range field.Keys {
-						if err := pkr.Set(key, field.DefaultValue); err != nil {
-							return marshalError(fmt.Errorf("invalid default for %q: %w", key, err))
-						}
+				for _, key := range field.Keys {
+					if err := pkr.Set(key, field.DefaultValue); err != nil {
+						return marshalError(fmt.Errorf("invalid default for %q: %w", key, err))
 					}
 				}
 			}
@@ -129,27 +108,6 @@ func generateURLString(serviceName, configJSON string) string {
 	for key, value := range values {
 		if value == "" {
 			continue
-		}
-
-		// Handle time.Duration fields by parsing them directly.
-		// PropKeyResolver.Set() tries to parse duration strings like "10s" as
-		// integers, which fails. Parse user-provided durations the same way
-		// defaults are handled above.
-		if field := configValue.FieldByName(key); field.IsValid() {
-			if field.Type() == reflect.TypeFor[time.Duration]() {
-				dur, err := time.ParseDuration(value)
-				if err != nil {
-					return marshalError(fmt.Errorf("invalid duration %q for %q: %w", value, key, err))
-				}
-
-				if !field.CanSet() {
-					return marshalError(fmt.Errorf("%w %q to %q", errCannotSetDurationField, key, value))
-				}
-
-				field.SetInt(int64(dur))
-
-				continue
-			}
 		}
 
 		if err := pkr.Set(key, value); err != nil {

--- a/pkg/format/doc.go
+++ b/pkg/format/doc.go
@@ -21,8 +21,8 @@
 // found in service configurations:
 //
 //   - Basic types: strings, integers, booleans
-//   - Duration types: time.Duration, parsed and rendered with Go duration syntax
-//     (e.g. "10s", "1h2m3s"); bare non-zero numbers are rejected, but "0" is
+//   - Duration types: [time.Duration], parsed and rendered with Go duration syntax
+//     (e.g. "10s", "1h2m3s"). Bare, non-zero numbers are rejected; however, "0" is
 //     accepted as the zero duration
 //   - Complex types: maps, slices, arrays, structs
 //   - Enum types: enumerated values with named options

--- a/pkg/format/doc.go
+++ b/pkg/format/doc.go
@@ -21,6 +21,9 @@
 // found in service configurations:
 //
 //   - Basic types: strings, integers, booleans
+//   - Duration types: time.Duration, parsed and rendered with Go duration syntax
+//     (e.g. "10s", "1h2m3s"); bare non-zero numbers are rejected, but "0" is
+//     accepted as the zero duration
 //   - Complex types: maps, slices, arrays, structs
 //   - Enum types: enumerated values with named options
 //

--- a/pkg/format/format_query_test.go
+++ b/pkg/format/format_query_test.go
@@ -2,6 +2,7 @@ package format
 
 import (
 	"net/url"
+	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -22,6 +23,19 @@ var _ = ginkgo.Describe("Query Formatter", func() {
 				query := BuildQuery(&pkr)
 				// (pkr, )
 				gomega.Expect(query).To(gomega.Equal("str=test"))
+			})
+		})
+		ginkgo.When("a duration property is at its default", func() {
+			ginkgo.It("should be omitted from the query string", func() {
+				query := BuildQuery(&pkr)
+				gomega.Expect(query).NotTo(gomega.ContainSubstring("duration="))
+			})
+		})
+		ginkgo.When("a duration property has been changed from default", func() {
+			ginkgo.It("should be included in the query string", func() {
+				ts.Duration = 30 * time.Second
+				query := BuildQuery(&pkr)
+				gomega.Expect(query).To(gomega.ContainSubstring("duration=30s"))
 			})
 		})
 		ginkgo.When("a custom query key conflicts with a config property key", func() {

--- a/pkg/format/format_test.go
+++ b/pkg/format/format_test.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -24,7 +25,8 @@ type subStruct struct {
 type testStruct struct {
 	Signed          int `default:"0"        key:"signed"`
 	Unsigned        uint
-	Str             string `default:"notempty" key:"str"`
+	Duration        time.Duration `default:"10s"      key:"duration"`
+	Str             string        `default:"notempty" key:"str"`
 	StrSlice        []string
 	StrArray        [3]string
 	Sub             subStruct

--- a/pkg/format/formatter.go
+++ b/pkg/format/formatter.go
@@ -93,6 +93,7 @@ func SetConfigField(config reflect.Value, field *FieldInfo, inputValue string) (
 	if field.EnumFormatter != nil {
 		return setEnumField(configField, field, inputValue)
 	}
+
 	if field.Type == durationType {
 		return setDurationField(configField, inputValue)
 	}

--- a/pkg/format/formatter.go
+++ b/pkg/format/formatter.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/nicholas-fedor/shoutrrr/pkg/types"
 	"github.com/nicholas-fedor/shoutrrr/pkg/util"
@@ -18,6 +19,8 @@ const (
 	Int32BitSize     = 32 // Bit size for 32-bit integers
 	Int64BitSize     = 64 // Bit size for 64-bit integers
 )
+
+var durationType = reflect.TypeFor[time.Duration]()
 
 // Errors defined as static variables for better error handling.
 var (
@@ -35,6 +38,7 @@ var (
 	ErrUnexpectedIntKind     = errors.New("unexpected int kind")
 	ErrParseIntFailed        = errors.New("failed to parse integer")
 	ErrParseUintFailed       = errors.New("failed to parse unsigned integer")
+	ErrParseDurationFailed   = errors.New("failed to parse duration")
 )
 
 // GetServiceConfig extracts the inner config from a service.
@@ -89,6 +93,9 @@ func SetConfigField(config reflect.Value, field *FieldInfo, inputValue string) (
 	if field.EnumFormatter != nil {
 		return setEnumField(configField, field, inputValue)
 	}
+	if field.Type == durationType {
+		return setDurationField(configField, inputValue)
+	}
 
 	switch field.Type.Kind() {
 	case reflect.String:
@@ -122,6 +129,18 @@ func SetConfigField(config reflect.Value, field *FieldInfo, inputValue string) (
 	default:
 		return false, fmt.Errorf("%w: %v", ErrInvalidFieldKind, field.Type.Kind())
 	}
+}
+
+// setDurationField handles time.Duration field setting.
+func setDurationField(configField reflect.Value, inputValue string) (bool, error) {
+	duration, err := time.ParseDuration(inputValue)
+	if err != nil {
+		return false, fmt.Errorf("%w: %w", ErrParseDurationFailed, err)
+	}
+
+	configField.SetInt(int64(duration))
+
+	return true, nil
 }
 
 // setIntField handles integer field setting.

--- a/pkg/format/formatter_test.go
+++ b/pkg/format/formatter_test.go
@@ -3,6 +3,7 @@ package format
 import (
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -73,6 +74,44 @@ var _ = ginkgo.Describe("SetConfigField", func() {
 					gomega.Expect(err).To(gomega.HaveOccurred())
 					gomega.Expect(valid).To(gomega.BeFalse())
 					gomega.Expect(ts.Unsigned).To(gomega.Equal(uint(2)))
+				})
+			})
+		})
+		ginkgo.When("setting a duration value", func() {
+			ginkgo.When("the value has a unit", func() {
+				ginkgo.It("should set it", func() {
+					valid, err := SetConfigField(tv, nodeMap["Duration"].Field(), "1h2m3s")
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					gomega.Expect(valid).To(gomega.BeTrue())
+					gomega.Expect(ts.Duration).
+						To(gomega.Equal(time.Hour + 2*time.Minute + 3*time.Second))
+				})
+			})
+			ginkgo.When("the value is a bare non-zero number", func() {
+				ginkgo.It("should return an error rather than assume nanoseconds", func() {
+					ts.Duration = time.Second
+					valid, err := SetConfigField(tv, nodeMap["Duration"].Field(), "10")
+					gomega.Expect(err).To(gomega.MatchError(ErrParseDurationFailed))
+					gomega.Expect(valid).To(gomega.BeFalse())
+					gomega.Expect(ts.Duration).To(gomega.Equal(time.Second))
+				})
+			})
+			ginkgo.When("the value is a bare zero", func() {
+				ginkgo.It("should be accepted as a zero duration", func() {
+					ts.Duration = time.Second
+					valid, err := SetConfigField(tv, nodeMap["Duration"].Field(), "0")
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					gomega.Expect(valid).To(gomega.BeTrue())
+					gomega.Expect(ts.Duration).To(gomega.BeZero())
+				})
+			})
+			ginkgo.When("the value is invalid", func() {
+				ginkgo.It("should return an error", func() {
+					ts.Duration = time.Second
+					valid, err := SetConfigField(tv, nodeMap["Duration"].Field(), "z7")
+					gomega.Expect(err).To(gomega.MatchError(ErrParseDurationFailed))
+					gomega.Expect(valid).To(gomega.BeFalse())
+					gomega.Expect(ts.Duration).To(gomega.Equal(time.Second))
 				})
 			})
 		})
@@ -206,6 +245,9 @@ var _ = ginkgo.Describe("SetConfigField", func() {
 			})
 			ginkgo.It("should format unsigned integers identical to input", func() {
 				testSetAndFormat(tv, nodeMap["Unsigned"], "5", "5")
+			})
+			ginkgo.It("should format durations identical to input", func() {
+				testSetAndFormat(tv, nodeMap["Duration"], "1h2m3s", "1h2m3s")
 			})
 			ginkgo.It("should format structs identical to input", func() {
 				testSetAndFormat(tv, nodeMap["SubProp"], "@whoa", "@whoa")

--- a/pkg/format/node.go
+++ b/pkg/format/node.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/nicholas-fedor/shoutrrr/pkg/types"
 	"github.com/nicholas-fedor/shoutrrr/pkg/util"
@@ -309,6 +310,8 @@ func getRootNode(value any) *ContainerNode {
 	}
 }
 
+// getValueNode wraps a field value in a ValueNode, pairing its rendered display
+// string with the token type used to color it.
 func getValueNode(fieldVal reflect.Value, fieldInfo *FieldInfo) *ValueNode {
 	value, tokenType := getValueNodeValue(fieldVal, fieldInfo)
 
@@ -319,6 +322,9 @@ func getValueNode(fieldVal reflect.Value, fieldInfo *FieldInfo) *ValueNode {
 	}
 }
 
+// getValueNodeValue renders a field value as its display string, along with the token
+// type used to color it. Enums print via their formatter and durations via Go duration
+// syntax; all other kinds are formatted from their reflect.Kind.
 func getValueNodeValue(fieldValue reflect.Value, fieldInfo *FieldInfo) (string, NodeTokenType) {
 	kind := fieldValue.Kind()
 
@@ -329,6 +335,9 @@ func getValueNodeValue(fieldValue reflect.Value, fieldInfo *FieldInfo) (string, 
 
 	if fieldInfo.IsEnum() {
 		return fieldInfo.EnumFormatter.Print(int(fieldValue.Int())), EnumToken
+	}
+	if fieldInfo.Type == durationType {
+		return time.Duration(fieldValue.Int()).String(), StringToken
 	}
 
 	switch kind {

--- a/pkg/format/node.go
+++ b/pkg/format/node.go
@@ -65,34 +65,56 @@ const (
 	BaseHexLen     = 16
 )
 
-// Field returns the inner FieldInfo.
+// Field returns the FieldInfo associated with this value node.
+//
+// Returns:
+//   - The node's FieldInfo.
 func (n *ValueNode) Field() *FieldInfo {
 	return n.FieldInfo
 }
 
-// TokenType returns a NodeTokenType that matches the value.
+// TokenType returns the syntax-highlighting token type for this node's value.
+//
+// Returns:
+//   - The NodeTokenType that matches the stored value.
 func (n *ValueNode) TokenType() NodeTokenType {
 	return n.tokenType
 }
 
-// Update updates the value string from the provided value.
+// Update refreshes the node's display string and token type from the provided value.
+//
+// Parameters:
+//   - tv: The reflected field value to render.
 func (n *ValueNode) Update(tv reflect.Value) {
 	value, token := getValueNodeValue(tv, n.FieldInfo)
 	n.Value = value
 	n.tokenType = token
 }
 
-// Field returns the inner FieldInfo.
+// Field returns the FieldInfo associated with this container node.
+//
+// Returns:
+//   - The node's FieldInfo.
 func (n *ContainerNode) Field() *FieldInfo {
 	return n.FieldInfo
 }
 
-// TokenType always returns ContainerToken for ContainerNode.
+// TokenType returns ContainerToken for every container node.
+//
+// Returns:
+//   - ContainerToken.
 func (n *ContainerNode) TokenType() NodeTokenType {
 	return ContainerToken
 }
 
-// Update updates the items to match the provided value.
+// Update rebuilds the container's child items to match the provided value.
+//
+// Array and slice values replace Items with one node per element.
+// Map values replace Items with one node per key, sorted by key name.
+// Other kinds are left unchanged.
+//
+// Parameters:
+//   - tv: The reflected container value to expand into child items.
 func (n *ContainerNode) Update(tv reflect.Value) {
 	switch n.Type.Kind() {
 	case reflect.Array, reflect.Slice:
@@ -129,6 +151,12 @@ func (n *ContainerNode) Update(tv reflect.Value) {
 	}
 }
 
+// updateArrayNode rebuilds the container's Items from an array or slice value.
+//
+// Each element becomes a ValueNode named by its index.
+//
+// Parameters:
+//   - arrayValue: The reflected array or slice to expand.
 func (n *ContainerNode) updateArrayNode(arrayValue reflect.Value) {
 	itemCount := arrayValue.Len()
 	n.Items = make([]Node, 0, itemCount)
@@ -155,6 +183,14 @@ func (n *ContainerNode) updateArrayNode(arrayValue reflect.Value) {
 	}
 }
 
+// getArrayNode builds a ContainerNode whose children represent the elements of an array or slice.
+//
+// Parameters:
+//   - arrayValue: The reflected array or slice to expand.
+//   - fieldInfo: Metadata for the array or slice field.
+//
+// Returns:
+//   - A ContainerNode with one child node per element.
 func getArrayNode(arrayValue reflect.Value, fieldInfo *FieldInfo) *ContainerNode {
 	node := &ContainerNode{
 		FieldInfo:    fieldInfo,
@@ -166,12 +202,23 @@ func getArrayNode(arrayValue reflect.Value, fieldInfo *FieldInfo) *ContainerNode
 	return node
 }
 
+// sortNodeItems sorts node items in place by their FieldInfo name.
+//
+// Parameters:
+//   - nodeItems: The slice of nodes to sort.
 func sortNodeItems(nodeItems []Node) {
 	sort.Slice(nodeItems, func(i, j int) bool {
 		return nodeItems[i].Field().Name < nodeItems[j].Field().Name
 	})
 }
 
+// updateMapNode rebuilds the container's Items from a map value.
+//
+// Each map entry becomes a ValueNode named by its string key.
+// Items are sorted by key, and MaxKeyLength is set to the longest key.
+//
+// Parameters:
+//   - mapValue: The reflected map to expand.
 func (n *ContainerNode) updateMapNode(mapValue reflect.Value) {
 	base := n.Base
 	if base == 0 {
@@ -210,6 +257,16 @@ func (n *ContainerNode) updateMapNode(mapValue reflect.Value) {
 	n.MaxKeyLength = maxKeyLength
 }
 
+// getMapNode builds a ContainerNode whose children represent the entries of a map.
+//
+// Pointer values are dereferenced before the map is expanded.
+//
+// Parameters:
+//   - mapValue: The reflected map, or a pointer to a map.
+//   - fieldInfo: Metadata for the map field.
+//
+// Returns:
+//   - A ContainerNode with one child node per map entry.
 func getMapNode(mapValue reflect.Value, fieldInfo *FieldInfo) *ContainerNode {
 	if mapValue.Kind() == reflect.Pointer {
 		mapValue = mapValue.Elem()
@@ -225,6 +282,17 @@ func getMapNode(mapValue reflect.Value, fieldInfo *FieldInfo) *ContainerNode {
 	return node
 }
 
+// getNode builds the tree node that represents a single config field.
+//
+// Arrays, slices, and maps become ContainerNodes.
+// Every other kind becomes a ValueNode.
+//
+// Parameters:
+//   - fieldVal: The reflected field value.
+//   - fieldInfo: Metadata for the field.
+//
+// Returns:
+//   - A Node for the field.
 func getNode(fieldVal reflect.Value, fieldInfo *FieldInfo) Node {
 	switch fieldInfo.Type.Kind() {
 	case reflect.Array, reflect.Slice:
@@ -261,6 +329,16 @@ func getNode(fieldVal reflect.Value, fieldInfo *FieldInfo) Node {
 	}
 }
 
+// getRootNode builds the root ContainerNode for a service config value.
+//
+// It reflects the struct fields, attaches enum formatters when the value
+// implements types.Enummer, and sorts the resulting child nodes by field name.
+//
+// Parameters:
+//   - value: The config value, typically a struct or a pointer to a struct.
+//
+// Returns:
+//   - A ContainerNode whose children represent the config fields.
 func getRootNode(value any) *ContainerNode {
 	structValue := reflect.ValueOf(value)
 	if structValue.Kind() == reflect.Pointer {
@@ -310,8 +388,16 @@ func getRootNode(value any) *ContainerNode {
 	}
 }
 
-// getValueNode wraps a field value in a ValueNode, pairing its rendered display
-// string with the token type used to color it.
+// getValueNode wraps a field value in a ValueNode.
+//
+// The node's Value is the rendered display string and tokenType is the token used to color it.
+//
+// Parameters:
+//   - fieldVal: The reflected field value to render.
+//   - fieldInfo: Metadata for the field.
+//
+// Returns:
+//   - A ValueNode pairing the display string with its token type.
 func getValueNode(fieldVal reflect.Value, fieldInfo *FieldInfo) *ValueNode {
 	value, tokenType := getValueNodeValue(fieldVal, fieldInfo)
 
@@ -322,9 +408,18 @@ func getValueNode(fieldVal reflect.Value, fieldInfo *FieldInfo) *ValueNode {
 	}
 }
 
-// getValueNodeValue renders a field value as its display string, along with the token
-// type used to color it. Enums print via their formatter and durations via Go duration
-// syntax; all other kinds are formatted from their reflect.Kind.
+// getValueNodeValue renders a field value as its display string and token type.
+//
+// Enums print via their formatter and durations via Go duration syntax.
+// All other kinds are formatted from their reflect.Kind.
+//
+// Parameters:
+//   - fieldValue: The reflected field value to render.
+//   - fieldInfo: Metadata for the field, including enum and duration type.
+//
+// Returns:
+//   - The display string for the value.
+//   - The NodeTokenType used to color that string.
 func getValueNodeValue(fieldValue reflect.Value, fieldInfo *FieldInfo) (string, NodeTokenType) {
 	kind := fieldValue.Kind()
 
@@ -336,6 +431,7 @@ func getValueNodeValue(fieldValue reflect.Value, fieldInfo *FieldInfo) (string, 
 	if fieldInfo.IsEnum() {
 		return fieldInfo.EnumFormatter.Print(int(fieldValue.Int())), EnumToken
 	}
+
 	if fieldInfo.Type == durationType {
 		return time.Duration(fieldValue.Int()).String(), StringToken
 	}
@@ -383,6 +479,17 @@ func getValueNodeValue(fieldValue reflect.Value, fieldInfo *FieldInfo) (string, 
 	}
 }
 
+// getContainerValueString renders an array, slice, or map as a single display string.
+//
+// Elements are joined with the field's ItemSeparator.
+// Map entries are written as key:value pairs and sorted by key.
+//
+// Parameters:
+//   - fieldValue: The reflected array, slice, or map to render.
+//   - fieldInfo: Metadata for the container field, including ItemSeparator and Base.
+//
+// Returns:
+//   - The joined display string for the container's items.
 func getContainerValueString(fieldValue reflect.Value, fieldInfo *FieldInfo) string {
 	itemSeparator := fieldInfo.ItemSeparator
 	sliceLength := fieldValue.Len()

--- a/pkg/generators/basic/basic.go
+++ b/pkg/generators/basic/basic.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/nicholas-fedor/shoutrrr/pkg/color"
 	"github.com/nicholas-fedor/shoutrrr/pkg/format"
@@ -124,8 +125,14 @@ func (g *Generator) getInputValue(
 		// More specific type validation
 		if field.Type != nil {
 			kind := field.Type.Kind()
-			if kind == reflect.Int || kind == reflect.Int8 || kind == reflect.Int16 ||
-				kind == reflect.Int32 || kind == reflect.Int64 {
+
+			switch {
+			case field.Type == reflect.TypeFor[time.Duration]():
+				if _, err := time.ParseDuration(input); err != nil {
+					return "", fmt.Errorf("invalid duration value for %s: %w", field.Name, err)
+				}
+			case kind == reflect.Int || kind == reflect.Int8 || kind == reflect.Int16 ||
+				kind == reflect.Int32 || kind == reflect.Int64:
 				if _, err := strconv.ParseInt(input, 10, field.Type.Bits()); err != nil {
 					return "", fmt.Errorf("invalid integer value for %s: %w", field.Name, err)
 				}

--- a/pkg/generators/basic/basic_test.go
+++ b/pkg/generators/basic/basic_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 	"text/template"
+	"time"
 
 	"github.com/nicholas-fedor/shoutrrr/pkg/format"
 	"github.com/nicholas-fedor/shoutrrr/pkg/types"
@@ -386,6 +387,24 @@ func TestGenerator_getInputValue(t *testing.T) {
 			input:   "\n",
 			want:    "localhost",
 			wantErr: false,
+		},
+		{
+			name:    "duration from user input",
+			field:   &format.FieldInfo{Name: "Timeout", Type: reflect.TypeFor[time.Duration]()},
+			propKey: "timeout",
+			props:   map[string]string{},
+			input:   "30s\n",
+			want:    "30s",
+			wantErr: false,
+		},
+		{
+			name:    "duration rejects a value without a unit",
+			field:   &format.FieldInfo{Name: "Timeout", Type: reflect.TypeFor[time.Duration]()},
+			propKey: "timeout",
+			props:   map[string]string{},
+			input:   "30\n",
+			want:    "",
+			wantErr: true,
 		},
 	}
 

--- a/pkg/services/email/smtp/smtp.go
+++ b/pkg/services/email/smtp/smtp.go
@@ -40,7 +40,7 @@ const (
 	contentMultipart            = "multipart/alternative; boundary=%s"
 	DefaultSMTPPort             = 25               // DefaultSMTPPort is the standard port for SMTP communication.
 	boundaryByteLen             = 8                // boundaryByteLen is the number of bytes for the multipart boundary.
-	DefaultTimeout              = 10               // DefaultTimeout is the default timout in seconds
+	DefaultTimeout              = 10               // DefaultTimeout is the default timeout in seconds
 	shortResponseErrorSubstring = "short response" // Error substring from textproto indicating a short response that is sometimes received during session closure.
 )
 

--- a/pkg/services/email/smtp/smtp_config.go
+++ b/pkg/services/email/smtp/smtp_config.go
@@ -106,15 +106,6 @@ func (c *Config) getURL(resolver types.ConfigQueryResolver) *url.URL {
 
 	queryParts := make([]string, 0, len(primaryKeys)+1)
 	for _, key := range primaryKeys {
-		if key == "timeout" {
-			queryParts = append(
-				queryParts,
-				fmt.Sprintf("%s=%s", key, url.QueryEscape(c.Timeout.String())),
-			)
-
-			continue
-		}
-
 		value, err := resolver.Get(key)
 		if err != nil {
 			continue // Skip invalid fields
@@ -148,17 +139,6 @@ func (c *Config) setURL(resolver types.ConfigQueryResolver, serviceURL *url.URL)
 	}
 
 	for key, vals := range serviceURL.Query() {
-		if key == "timeout" {
-			duration, err := time.ParseDuration(vals[0])
-			if err != nil {
-				return fmt.Errorf("parsing timeout parameter %q: %w", vals[0], err)
-			}
-
-			c.Timeout = duration
-
-			continue
-		}
-
 		if err := resolver.Set(key, vals[0]); err != nil {
 			return fmt.Errorf("setting query parameter %q to %q: %w", key, vals[0], err)
 		}

--- a/pkg/services/email/smtp/smtp_test.go
+++ b/pkg/services/email/smtp/smtp_test.go
@@ -826,6 +826,50 @@ var _ = ginkgo.Describe("the SMTP service", func() {
 		})
 	})
 
+	ginkgo.When("configuring timeout via params", func() {
+		ginkgo.It("should use the specified timeout", func() {
+			config := &Config{}
+			resolver := format.NewPropKeyResolver(config)
+			params := types.Params{"timeout": "1h2m3s"}
+
+			err := resolver.UpdateConfigFromParams(config, &params)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(config.Timeout).To(gomega.Equal(1*time.Hour + 2*time.Minute + 3*time.Second))
+		})
+
+		ginkgo.It("should reject a bare non-zero timeout value", func() {
+			config := &Config{Timeout: 5 * time.Second}
+			resolver := format.NewPropKeyResolver(config)
+			params := types.Params{"timeout": "10"}
+
+			err := resolver.UpdateConfigFromParams(config, &params)
+			gomega.Expect(err).To(gomega.MatchError(format.ErrParseDurationFailed))
+			gomega.Expect(config.Timeout).To(gomega.Equal(5 * time.Second))
+		})
+	})
+
+	ginkgo.When("applying the default props", func() {
+		ginkgo.It("should apply the tagged timeout default", func() {
+			config := &Config{}
+			resolver := format.NewPropKeyResolver(config)
+
+			gomega.Expect(resolver.SetDefaultProps(config)).To(gomega.Succeed())
+			gomega.Expect(config.Timeout).To(gomega.Equal(DefaultTimeout * time.Second))
+		})
+	})
+
+	ginkgo.When("serializing the timeout", func() {
+		ginkgo.It("should render it as a duration rather than a nanosecond count", func() {
+			config := &Config{}
+			resolver := format.NewPropKeyResolver(config)
+			config.Timeout = 10 * time.Second
+
+			value, err := resolver.Get("timeout")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(value).To(gomega.Equal("10s"))
+		})
+	})
+
 	ginkgo.It("returns the correct service identifier", func() {
 		gomega.Expect(service.GetID()).To(gomega.Equal("smtp"))
 	})


### PR DESCRIPTION
format had no `time.Duration` awareness. Because `time.Duration` has a `reflect.Int64` kind, Duration config fields were handled as plain integers.

- `SetConfigField` used `strconv.ParseInt`, so `timeout=10s` failed while a bare `timeout=10` silently meant 10 nanoseconds.
- `SetDefaultProps` errored on `default:"10s"` and left `Timeout` at zero. smtp's `Initialize` hardcodes the same value, so only direct `SetDefaultProps` callers saw the dead tag.
- the render path emitted the raw nanosecond count, so `shoutrrr verify`/`docs` printed `Timeout 10000000000` next to `<Default: 10s>`. smtp's own URLs were unaffected, since its bespoke `getURL` branch called
`Timeout.String()` directly — which is what kept the bug hidden.

Adds type-based Duration matching with a parse/render pair, so durations round-trip in `1h2m3s` notation in both directions. Parsing is strict `time.ParseDuration`, so a bare number is rejected rather than read as nanoseconds (`shoutrrr generate smtp` translates `Timeout[10s]: 10` to `timeout=10ns`).

With this fixed, two workarounds became redundant and were trimmed.
- the timeout catch in `smtp_config.go`'s `getURL`/`setURL`
- the duration branches in the WASM playground

A third site needed the opposite. The interactive generator pre-validates Int64-kind fields with `ParseInt`, so without a guard this change would have left `shoutrrr generate smtp` unable to accept any Timeout value `30s`, and `30` previously went through as 30ns. It now matches Duration on type first.

This PR:
```
./shoutrrr generate smtp
Generating URL for smtp using basic generator
...
Timeout[10s]: 10s

URL: smtp://localhost:25/?auth=Unknown&clienthost=localhost&encryption=Auto&fromaddress=a%40example.com&subject=Shoutrrr+Notification&toaddresses=a%40example.com&usehtml=No&usestarttls=Yes&timeout=10s
```

0.18.0:
```
shoutrrr-0.18.0/shoutrrr generate smtp
Generating URL for smtp using basic generator
...
Timeout[10s]: 10s
Error: invalid integer value for Timeout: strconv.ParseInt: parsing "10s": invalid syntax
```

`smtp.Timeout` is currently the only `time.Duration` in any service config, but the fix is keyed on the type, so future Duration fields work without per-service handling.