### PR TITLE
fix(email): avoid SMTP close warning after successful send

### DIFF
--- a/pkg/services/email/smtp/smtp_session.go
+++ b/pkg/services/email/smtp/smtp_session.go
@@ -17,7 +17,7 @@ type session struct {
 	config *Config
 	// svc provides logging and message templates.
 	svc *Service
-	// closed is true after [session.quit] has closed the client.
+	// closed is true after the connection has been closed by Quit or Close.
 	closed bool
 }
 
@@ -59,6 +59,7 @@ func (s *session) closeIfOpen() {
 	}
 
 	s.closeClient()
+	s.closed = true
 }
 
 // deliver sends the message to each configured recipient.
@@ -114,10 +115,12 @@ func (s *session) ehloName() string {
 	return hostname
 }
 
-// quit ends the SMTP session with QUIT and closes the client.
+// quit ends the SMTP session with QUIT.
 //
-// Errors matching [shortResponseErrorSubstring] on QUIT are logged and ignored
-// because they do not affect delivery. Other QUIT errors are appended to errs.
+// A successful [smtp.Client.Quit] already closes the connection, so Close is
+// not called again. When QUIT fails, the client is closed explicitly.
+// Errors matching [shortResponseErrorSubstring] are logged and ignored because
+// they do not affect delivery. Other QUIT errors are appended to errs.
 //
 // Parameters:
 //   - errs: Accumulated delivery errors to extend if QUIT fails.
@@ -125,18 +128,21 @@ func (s *session) ehloName() string {
 // Returns:
 //   - The original error slice, possibly with a session-closure failure appended.
 func (s *session) quit(errs []error) []error {
-	if err := s.client.Quit(); err != nil {
-		// Ignore known "short response" errors from quirky servers (e.g., Office 365 on close),
-		// as they don't impact delivery.
-		if strings.Contains(err.Error(), shortResponseErrorSubstring) {
-			s.svc.Logf("Warning: Ignoring session closure error (delivery succeeded): %v", err)
-		} else {
-			errs = append(errs, fail(FailClosingSession, err))
-		}
+	err := s.client.Quit()
+	if err == nil {
+		s.closed = true
+
+		return errs
 	}
 
-	s.closed = true
+	if strings.Contains(err.Error(), shortResponseErrorSubstring) {
+		s.svc.Logf("Warning: Ignoring session closure error (delivery succeeded): %v", err)
+	} else {
+		errs = append(errs, fail(FailClosingSession, err))
+	}
+
 	s.closeClient()
+	s.closed = true
 
 	return errs
 }

--- a/pkg/services/email/smtp/smtp_session_test.go
+++ b/pkg/services/email/smtp/smtp_session_test.go
@@ -73,6 +73,7 @@ var _ = ginkgo.Describe("session", func() {
 			sess.closed = false
 			sess.closeIfOpen()
 			gomega.Expect(mock.closeCount).To(gomega.Equal(1))
+			gomega.Expect(sess.closed).To(gomega.BeTrue())
 		})
 	})
 
@@ -721,7 +722,7 @@ var _ = ginkgo.Describe("session", func() {
 					To(gomega.ContainSubstring("Warning: Ignoring session closure error (delivery succeeded)"))
 			})
 
-			ginkgo.It("should log warning when QUIT succeeds but Close fails", func() {
+			ginkgo.It("should not close again after a successful QUIT", func() {
 				serviceURL, _ := url.Parse(baseNoAuthURL)
 				localService := &Service{}
 				gomega.Expect(localService.Initialize(serviceURL, logger)).To(gomega.Succeed())
@@ -745,11 +746,14 @@ var _ = ginkgo.Describe("session", func() {
 				textCon, _ := testutils.CreateTextConFaker(responses, "\r\n")
 				client := &smtp.Client{Text: textCon}
 				fakeTLSEnabled(client, serviceURL.Hostname())
-				injectConn(client, &mockConn{})
+
+				mock := &mockConn{}
+				injectConn(client, mock)
 
 				gomega.Expect(runSMTPSession(localService, client, localService.Config)).To(gomega.Succeed())
 				gomega.Expect(buf.String()).
-					To(gomega.ContainSubstring("Warning: Failed to close SMTP client connection: mock close error"))
+					NotTo(gomega.ContainSubstring("Failed to close SMTP client connection"))
+				gomega.Expect(mock.closeCount).To(gomega.Equal(1))
 			})
 
 			ginkgo.It("should close the client when the handshake fails", func() {


### PR DESCRIPTION
This PR fixes a close-failure warning Shoutrrr would log after an SMTP notification had already been sent.

## Problem

A successful SMTP send from Shoutrrr would end with a `Failed to close SMTP client connection: use of closed network connection` warning that indicated the client connection could not be closed. 

This was because `Close` ran after `Quit` had already closed the socket.

## Solution

Corrected the SMTP service to not call `Close` after `Quit` succeeds. `Quit` already closes the connection in that case, so the second close was the source of the warning. 

`Close` remains in place for failed `Quit` and for sessions that never reach `Quit`.

## Changes

- Skip Close after a successful QUIT.
- Set closed in closeIfOpen so deferred cleanup does not Close twice.
- Assert one close and no close-failure warning in the session tests.