### PR TITLE
chore: update minimum supported Go version to 1.27

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Heavily inspired by <a href="https://github.com/caronc/apprise">caronc/apprise</
   - [Binaries](#binaries)
   - [Container Images](#container-images)
   - [Go Package](#go-package)
+    - [Minimum Supported Version Policy](#minimum-supported-version-policy)
   - [GitHub Action](#github-action)
 - [Usage](#usage)
   - [CLI](#cli)
@@ -113,6 +114,10 @@ Install the latest release binary to `$HOME/go/bin` (ensure it's in your `PATH`)
 ```bash
 go get github.com/nicholas-fedor/shoutrrr@latest
 ```
+
+#### Minimum Supported Version Policy
+
+Projects importing Shoutrrr are expected to follow the latest Go minor and/or patch semantic version; ergo, Shoutrrr follows the latest minor Go version, i.e. 1.27.
 
 ### GitHub Action
 

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -74,6 +74,10 @@ Add Shoutrrr to your Go project using:
 go get github.com/nicholas-fedor/shoutrrr@latest
 ```
 
+### Minimum Supported Version Policy
+
+Projects importing Shoutrrr are expected to follow the latest Go minor and/or patch semantic version; ergo, Shoutrrr follows the latest minor Go version, i.e. 1.27.
+
 ## GitHub Action
 
 Use Shoutrrr in GitHub workflows to send notifications.

--- a/docs/usage/go-package/index.md
+++ b/docs/usage/go-package/index.md
@@ -4,6 +4,12 @@
 
 The Shoutrrr Go package (`github.com/nicholas-fedor/shoutrrr`) enables sending notifications to various services (e.g., `discord`, `slack`, `telegram`, `smtp`, etc.) using service URLs. It provides two primary methods: a direct `Send` function for simple use cases and a `Sender` struct for advanced scenarios with multiple URLs, message queuing, and parameter customization.
 
+### Minimum Supported Go Version
+
+Projects importing Shoutrrr are expected to follow the latest Go minor and/or patch semantic versions; ergo, Shoutrrr follows the latest minor Go version, i.e. 1.27. (Go refers to minor semantic version releases as major releases.)
+
+Go release information can be reviewed here: <https://go.dev/doc/devel/release>
+
 ## Usage
 
 ```go title="Go Import Statement"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nicholas-fedor/shoutrrr
 
-go 1.25.0
+go 1.27
 
 toolchain go1.27.1
 


### PR DESCRIPTION
This PR raises Shoutrrr's minimum supported Go version to 1.27 and documents the ongoing support policy.

## Problem

While Shoutrrr previously split the Go version and toolchain version to improve compatibility with Go patch versions, no minor version policy was implemented, thus leaving Shoutrrr behind a with Go 1.25 and previously failing to update to 1.26.

This ultimately prevents Shoutrrr's codebase from being modernized and leveraging recent improvements.

## Solution

Update Shoutrrr to use the latest Go major release version (1.27) and also document the ongoing policy. 

Given the importance and pace of updates to Go, along with the benefits to modernizing Shoutrrr's codebase, it's no longer viable to maintain compatibility for less than the current major Go release version.

## Changes

- Raise the module `go` directive to 1.27
- Document the minimum supported Go version policy