### PR TITLE
feat: add support for injecting custom DialContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ sender.Send("Hello world (or slack channel) !", &params)
 import (
     "context"
     "crypto/tls"
+    "fmt"
     "log"
     "net"
     "net/http"
@@ -208,7 +209,25 @@ import (
 )
 
 dial := func(ctx context.Context, network, addr string) (net.Conn, error) {
-    return (&net.Dialer{}).DialContext(ctx, network, addr)
+    host, port, err := net.SplitHostPort(addr)
+    if err != nil {
+        return nil, err
+    }
+    ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+    if err != nil {
+        return nil, err
+    }
+    d := &net.Dialer{}
+    for _, ip := range ips {
+        if ip.IP.IsLoopback() || ip.IP.IsPrivate() || ip.IP.IsLinkLocalUnicast() || ip.IP.IsLinkLocalMulticast() {
+            continue
+        }
+        conn, err := d.DialContext(ctx, network, net.JoinHostPort(ip.IP.String(), port))
+        if err == nil {
+            return conn, nil
+        }
+    }
+    return nil, &net.OpError{Op: "dial", Net: network, Err: fmt.Errorf("destination blocked by egress policy")}
 }
 
 customClient := &http.Client{

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Heavily inspired by <a href="https://github.com/caronc/apprise">caronc/apprise</
     - [Option 2 - Using a sender](#option-2---using-a-sender)
       - [Single URL](#single-url)
       - [Multiple URLs](#multiple-urls)
-      - [Custom HTTP Client (SSRF / Egress Control)](#custom-http-client-ssrf--egress-control)
+      - [Custom HTTP Client and DialContext (SSRF / Egress Control)](#custom-http-client-and-dialcontext-ssrf--egress-control)
       - [Message Levels](#message-levels)
       - [Per-Target Errors](#per-target-errors)
       - [Context Propagation](#context-propagation)
@@ -191,27 +191,36 @@ params := types.Params{}
 sender.Send("Hello world (or slack channel) !", &params)
 ```
 
-##### Custom HTTP Client (SSRF / Egress Control)
+##### Custom HTTP Client and DialContext (SSRF / Egress Control)
+
+`shoutrrr.Send` cannot take these options. Use `NewSenderWithOptions` (or `CreateSenderWithOptions`).
 
 ```go
 import (
+    "context"
     "crypto/tls"
     "log"
+    "net"
     "net/http"
 
     "github.com/nicholas-fedor/shoutrrr"
     "github.com/nicholas-fedor/shoutrrr/pkg/types"
 )
 
+dial := func(ctx context.Context, network, addr string) (net.Conn, error) {
+    return (&net.Dialer{}).DialContext(ctx, network, addr)
+}
+
 customClient := &http.Client{
     Transport: &http.Transport{
+        DialContext:     dial,
         TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12},
     },
 }
 
 sender, err := shoutrrr.NewSenderWithOptions(
     nil,
-    types.SenderOptions{HTTPClient: customClient},
+    types.SenderOptions{HTTPClient: customClient, DialContext: dial},
     "discord://token@channel",
 )
 if err != nil {

--- a/docs/guides/proxy/index.md
+++ b/docs/guides/proxy/index.md
@@ -44,34 +44,37 @@ import (
  "github.com/nicholas-fedor/shoutrrr/pkg/types"
 )
 
-// isAllowedHost is an example SSRF guard. Implement your own policy.
-func isAllowedHost(host string) bool {
- // Reject loopback, private, link-local, etc. Adjust to your needs.
- ip := net.ParseIP(host)
- if ip == nil {
-  // For hostnames you may resolve or apply allow-list here.
-  return true
+// isBlockedIP is an example SSRF guard. Implement your own policy.
+func isBlockedIP(ip net.IP) bool {
+ return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()
+}
+
+func dialAllowed(ctx context.Context, network, addr string) (net.Conn, error) {
+ host, port, err := net.SplitHostPort(addr)
+ if err != nil {
+  return nil, err
  }
- if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
-  return false
+ ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+ if err != nil {
+  return nil, err
  }
- return true
+ d := &net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}
+ for _, ip := range ips {
+  if isBlockedIP(ip.IP) {
+   continue
+  }
+  conn, err := d.DialContext(ctx, network, net.JoinHostPort(ip.IP.String(), port))
+  if err == nil {
+   return conn, nil
+  }
+ }
+ return nil, &net.OpError{Op: "dial", Net: network, Err: fmt.Errorf("destination blocked by egress policy")}
 }
 
 func main() {
  // Custom Transport with DialContext that performs egress/SSRF checks.
  transport := &http.Transport{
-  DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-   host, _, err := net.SplitHostPort(addr)
-   if err != nil {
-    host = addr // no port
-   }
-   if !isAllowedHost(host) {
-    return nil, &net.OpError{Op: "dial", Net: network, Addr: nil, Err: fmt.Errorf("destination blocked by egress policy")}
-   }
-   d := &net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}
-   return d.DialContext(ctx, network, addr)
-  },
+  DialContext: dialAllowed,
   // Proxy: http.ProxyFromEnvironment, // opt-in if you also want env proxies for this client
   ForceAttemptHTTP2:     true,
   MaxIdleConns:          100,
@@ -137,6 +140,7 @@ func main() {
 
     import (
         "context"
+        "fmt"
         "log"
         "net"
         "net/http"
@@ -146,22 +150,32 @@ func main() {
         "github.com/nicholas-fedor/shoutrrr/pkg/types"
     )
 
-    func isAllowedHost(host string) bool {
-        ip := net.ParseIP(host)
-        if ip == nil {
-            return true
-        }
-        return !ip.IsLoopback() && !ip.IsPrivate()
+    func isBlockedIP(ip net.IP) bool {
+        return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()
     }
 
     func main() {
         transport := &http.Transport{
             DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-                host, _, _ := net.SplitHostPort(addr)
-                if !isAllowedHost(host) {
-                    return nil, context.DeadlineExceeded
+                host, port, err := net.SplitHostPort(addr)
+                if err != nil {
+                    return nil, err
                 }
-                return (&net.Dialer{Timeout: 30 * time.Second}).DialContext(ctx, network, addr)
+                ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+                if err != nil {
+                    return nil, err
+                }
+                d := &net.Dialer{Timeout: 30 * time.Second}
+                for _, ip := range ips {
+                    if isBlockedIP(ip.IP) {
+                        continue
+                    }
+                    conn, err := d.DialContext(ctx, network, net.JoinHostPort(ip.IP.String(), port))
+                    if err == nil {
+                        return conn, nil
+                    }
+                }
+                return nil, &net.OpError{Op: "dial", Net: network, Err: fmt.Errorf("destination blocked by egress policy")}
             },
         }
         custom := &http.Client{Transport: transport}

--- a/docs/guides/proxy/index.md
+++ b/docs/guides/proxy/index.md
@@ -4,7 +4,9 @@
 
 Shoutrrr supports proxying HTTP requests for notification services, allowing you to route traffic through a proxy server. This can be configured using an environment variable or by customizing the HTTP client in code.
 
-**For per-sender egress control and SSRF protection (recommended for untrusted notification URLs), use a custom `http.Client` via `SenderOptions`.**
+**For per-sender egress control and SSRF protection (recommended for untrusted notification URLs), use a custom `http.Client` and `DialContext` via `SenderOptions`.**
+
+`shoutrrr.Send` cannot take these options. Use `shoutrrr.NewSenderWithOptions`, `CreateSenderWithOptions`, or `router.NewWithOptions`.
 
 ## Usage
 
@@ -83,10 +85,11 @@ func main() {
   Timeout:   60 * time.Second,
  }
 
- opts := types.SenderOptions{
-  HTTPClient: customClient,
-  // Timeout: 30 * time.Second, // optional per-router override
- }
+  opts := types.SenderOptions{
+   HTTPClient:  customClient,
+   DialContext: transport.DialContext,
+   // Timeout: 30 * time.Second, // optional per-router override
+  }
 
  url := "discord://abc123@123456789"
  sender, err := shoutrrr.NewSenderWithOptions(nil, opts, url)
@@ -102,11 +105,13 @@ func main() {
 }
 ```
 
-**Notes on custom clients:**
+**Notes on custom clients and dialers:**
 
 - A non-nil `SenderOptions.HTTPClient` is propagated by the router to services implementing `types.HTTPClientSetter`.
+- A non-nil `SenderOptions.DialContext` is propagated to services implementing `types.DialContextSetter` (SMTP and MQTT). TLS wrapping still happens after the TCP dial.
+- `DialContext` must be safe for concurrent use. A custom dialer bypasses MQTT `all_proxy`; implement proxying in the function if needed.
 - Custom clients usually bypass `HTTP_PROXY`/`HTTPS_PROXY` unless their `Transport.Proxy` is configured to consult the environment.
-- All default timeouts/TLS behavior is preserved when no custom client is supplied.
+- All default timeouts/TLS behavior is preserved when no custom client or dialer is supplied.
 - The same client instance is reused for the lifetime of the sender/router.
 
 ## Examples
@@ -161,7 +166,7 @@ func main() {
         }
         custom := &http.Client{Transport: transport}
 
-        sender, err := shoutrrr.NewSenderWithOptions(nil, types.SenderOptions{HTTPClient: custom}, "discord://abc123@123456789")
+        sender, err := shoutrrr.NewSenderWithOptions(nil, types.SenderOptions{HTTPClient: custom, DialContext: transport.DialContext}, "discord://abc123@123456789")
         if err != nil {
             log.Fatal(err)
         }
@@ -186,5 +191,6 @@ func main() {
 
 - **Environment Variable**: `HTTP_PROXY` supports protocols like `http`, `https`, or `socks5`. It affects all HTTP-based services globally.
 - **Custom HTTP Client**: Provides fine-grained control over proxy settings, suitable for Go applications requiring specific transport configurations.
+- **Custom DialContext**: Applies the same destination policy to SMTP and MQTT TCP connections. HTTP services continue to use `HTTPClient`.
 - **Service Compatibility**: Ensure the proxy supports the protocol used by the service (e.g., HTTPS for Discord, SMTP).
 - **Timeouts**: The custom client example includes a 30-second dial timeout and 10-second TLS handshake timeout, adjustable as needed.

--- a/docs/usage/go-package/index.md
+++ b/docs/usage/go-package/index.md
@@ -37,6 +37,7 @@ Sends a notification to a single service URL.
 Creates a `Sender` (`*ServiceRouter`) to manage multiple service URLs, support message queuing, and allow parameter customization.
 
 - **Function**: `shoutrrr.CreateSender(urls ...string) (*ServiceRouter, error)`
+- **With options**: `shoutrrr.NewSenderWithOptions` / `CreateSenderWithOptions` accept `types.SenderOptions`. `HTTPClient` is injected into HTTP services. `DialContext` is injected into TCP services that implement `types.DialContextSetter`. `shoutrrr.Send` cannot take these options.
 - **Methods**:
   - `Send(message string, params *types.Params) []error`: Sends a message to all configured services.
   - `SendItems(items []types.MessageItem, params types.Params) []error`: Sends structured message items to services that support rich formatting.

--- a/internal/testutils/testutils_test.go
+++ b/internal/testutils/testutils_test.go
@@ -112,10 +112,8 @@ var _ = ginkgo.Describe("the testutils package", func() {
 
 		ginkgo.BeforeEach(func() {
 			service = dummyService{
-				Standard: standard.Standard{
-					Logger:    standard.Logger{},
-					Templater: standard.Templater{},
-				},
+				Logger:    standard.Logger{},
+				Templater: standard.Templater{},
 				Config: dummyConfig{
 					EnumlessConfig: standard.EnumlessConfig{},
 					Foo:            0,

--- a/internal/testutils/testutils_test.go
+++ b/internal/testutils/testutils_test.go
@@ -112,8 +112,6 @@ var _ = ginkgo.Describe("the testutils package", func() {
 
 		ginkgo.BeforeEach(func() {
 			service = dummyService{
-				Logger:    standard.Logger{},
-				Templater: standard.Templater{},
 				Config: dummyConfig{
 					EnumlessConfig: standard.EnumlessConfig{},
 					Foo:            0,

--- a/pkg/color/color.go
+++ b/pkg/color/color.go
@@ -96,7 +96,7 @@ func NewWithConfig(cfg *Config, value ...Attribute) *Color {
 	}
 
 	if cfg.NoColor {
-		c.noColor = boolPtr(true)
+		c.noColor = new(true)
 	}
 
 	c.Add(value...)
@@ -150,14 +150,14 @@ func (c *Color) AddRGB(r, green, blue int) *Color {
 // Can be used for flags like "--no-color".
 // To enable back use EnableColor() method.
 func (c *Color) DisableColor() {
-	c.noColor = boolPtr(true)
+	c.noColor = new(true)
 }
 
 // EnableColor enables the color output.
 // Use it in conjunction with DisableColor().
 // Otherwise, this method has no side effects.
 func (c *Color) EnableColor() {
-	c.noColor = boolPtr(false)
+	c.noColor = new(false)
 }
 
 // Equals returns a boolean value indicating whether two colors are equal.

--- a/pkg/color/util.go
+++ b/pkg/color/util.go
@@ -6,8 +6,9 @@ import (
 	"strings"
 )
 
+//go:fix inline
 func boolPtr(v bool) *bool {
-	return &v
+	return new(v)
 }
 
 // noColorIsSet returns true if the NO_COLOR environment variable is set (regardless of value).

--- a/pkg/color/util.go
+++ b/pkg/color/util.go
@@ -7,6 +7,7 @@ import (
 )
 
 //go:fix inline
+//nolint:unused // Retained as a go:fix inline helper after call sites were rewritten to new(expr).
 func boolPtr(v bool) *bool {
 	return new(v)
 }

--- a/pkg/color/util_bench_test.go
+++ b/pkg/color/util_bench_test.go
@@ -8,8 +8,8 @@ import (
 // Benchmark_boolPtr benchmarks the boolPtr function for creating boolean pointers.
 func Benchmark_boolPtr(b *testing.B) {
 	for b.Loop() {
-		_ = boolPtr(true)
-		_ = boolPtr(false)
+		_ = new(true)
+		_ = new(false)
 	}
 }
 

--- a/pkg/color/util_test.go
+++ b/pkg/color/util_test.go
@@ -39,7 +39,7 @@ func Test_boolPtr(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result := boolPtr(tt.input)
+			result := new(tt.input)
 			tt.checkPtr(t, result)
 		})
 	}

--- a/pkg/router/doc.go
+++ b/pkg/router/doc.go
@@ -55,10 +55,12 @@
 //
 //	err := service.Send("Hello, World!", nil)
 //
-// For SSRF protection or custom egress control, supply a custom HTTP client:
+// For SSRF protection or custom egress control, supply a custom HTTP client
+// and DialContext:
 //
 //	opts := types.SenderOptions{
-//	    HTTPClient: myClient,
+//	    HTTPClient:  myClient,
+//	    DialContext: myDial,
 //	}
 //	router, err := router.NewWithOptions(logger, opts, "slack://webhook/...")
 //	if err != nil {

--- a/pkg/router/doc.go
+++ b/pkg/router/doc.go
@@ -55,8 +55,9 @@
 //
 //	err := service.Send("Hello, World!", nil)
 //
-// For SSRF protection or custom egress control, supply a custom HTTP client
-// and DialContext:
+// For SSRF protection or custom egress control, set HTTPClient for HTTP
+// services such as this slack:// URL. DialContext applies only to non-HTTP
+// TCP services (SMTP and MQTT).
 //
 //	opts := types.SenderOptions{
 //	    HTTPClient:  myClient,

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -14,11 +14,12 @@ import (
 
 // ServiceRouter is responsible for routing a message to a specific notification service using the notification URL.
 type ServiceRouter struct {
-	logger     types.StdLogger
-	services   []types.Service
-	queue      []string
-	Timeout    time.Duration
-	httpClient types.HTTPClient
+	logger      types.StdLogger
+	services    []types.Service
+	queue       []string
+	Timeout     time.Duration
+	httpClient  types.HTTPClient
+	dialContext types.DialContextFunc
 	//nolint:containedctx // Intentional: router derives per-service timeout contexts from this base.
 	ctx context.Context
 }
@@ -47,11 +48,12 @@ func New(logger types.StdLogger, serviceURLs ...string) (*ServiceRouter, error) 
 
 // NewWithOptions creates a new service router using the specified logger, options,
 // and service URLs. If opts.HTTPClient is non-nil, it will be injected into
-// services that support it (via SetHTTPClient or internal client replacement).
+// services that support it (via SetHTTPClient). If opts.DialContext is non-nil,
+// it will be injected into services that implement [types.DialContextSetter].
 //
 // Parameters:
 //   - logger: the logger to use for service output.
-//   - opts: the sender options, including timeout and HTTP client.
+//   - opts: the sender options, including timeout, HTTP client, and dial function.
 //   - serviceURLs: the service URLs to initialize.
 //
 // Returns:
@@ -59,12 +61,13 @@ func New(logger types.StdLogger, serviceURLs ...string) (*ServiceRouter, error) 
 //   - error: an error if any service fails to initialize.
 func NewWithOptions(logger types.StdLogger, opts types.SenderOptions, serviceURLs ...string) (*ServiceRouter, error) {
 	router := ServiceRouter{
-		logger:     logger,
-		services:   nil,
-		queue:      nil,
-		Timeout:    DefaultTimeout,
-		httpClient: opts.HTTPClient,
-		ctx:        context.Background(),
+		logger:      logger,
+		services:    nil,
+		queue:       nil,
+		Timeout:     DefaultTimeout,
+		httpClient:  opts.HTTPClient,
+		dialContext: opts.DialContext,
+		ctx:         context.Background(),
 	}
 
 	if opts.Timeout > 0 {
@@ -349,6 +352,12 @@ func (r *ServiceRouter) initService(rawURL string) (types.Service, error) {
 			// skip typed-nil
 		} else if setter, ok := service.(types.HTTPClientSetter); ok {
 			setter.SetHTTPClient(r.httpClient)
+		}
+	}
+
+	if r.dialContext != nil {
+		if setter, ok := service.(types.DialContextSetter); ok {
+			setter.SetDialContext(r.dialContext)
 		}
 	}
 

--- a/pkg/services/chat/discord/discord_sender.go
+++ b/pkg/services/chat/discord/discord_sender.go
@@ -171,14 +171,12 @@ func isTransientError(err error) bool {
 		return true
 	}
 
-	var netErr net.Error
-	if errors.As(err, &netErr) {
+	if netErr, ok := errors.AsType[net.Error](err); ok {
 		return netErr.Timeout() ||
 			netErr.Temporary() //nolint:staticcheck // Temporary is deprecated but still used for compatibility
 	}
 
-	var urlErr *url.Error
-	if errors.As(err, &urlErr) {
+	if urlErr, ok := errors.AsType[*url.Error](err); ok {
 		return isTransientError(urlErr.Err)
 	}
 

--- a/pkg/services/chat/matrix/matrix_client.go
+++ b/pkg/services/chat/matrix/matrix_client.go
@@ -496,8 +496,7 @@ func isRateLimitedError(err error) bool {
 		return false
 	}
 
-	var apiErr *apiResError
-	if errors.As(err, &apiErr) {
+	if apiErr, ok := errors.AsType[*apiResError](err); ok {
 		return apiErr.IsRateLimited()
 	}
 

--- a/pkg/services/email/smtp/smtp.go
+++ b/pkg/services/email/smtp/smtp.go
@@ -21,6 +21,8 @@ type Service struct {
 	Config *Config
 	// propKeyResolver applies URL and send-parameter overrides to [Config].
 	propKeyResolver format.PropKeyResolver
+	// dialContext, if non-nil, is used for the SMTP TCP dial.
+	dialContext types.DialContextFunc
 }
 
 const (
@@ -30,7 +32,10 @@ const (
 	defaultTimeout = 10 * time.Second
 )
 
-var _ types.ContextSender = (*Service)(nil)
+var (
+	_ types.ContextSender     = (*Service)(nil)
+	_ types.DialContextSetter = (*Service)(nil)
+)
 
 // GetID returns the service identifier.
 //
@@ -129,7 +134,7 @@ func (s *Service) SendContext(ctx context.Context, message string, params *types
 	)
 	defer cancel()
 
-	client, err := dialClient(ctx, &config)
+	client, err := dialClient(ctx, &config, s.dialContext)
 	if err != nil {
 		return fail(FailGetSMTPClient, err)
 	}
@@ -140,6 +145,17 @@ func (s *Service) SendContext(ctx context.Context, message string, params *types
 		svc:    s,
 		closed: false,
 	}).run(message)
+}
+
+// SetDialContext sets a custom dial function for SMTP TCP connections.
+//
+// TLS wrapping for implicit TLS still happens after the TCP dial.
+// A nil dial restores the default [net.Dialer].
+//
+// Parameters:
+//   - dial: The dial function. Must be safe for concurrent use when non-nil.
+func (s *Service) SetDialContext(dial types.DialContextFunc) {
+	s.dialContext = dial
 }
 
 // effectiveTimeout returns a positive SMTP timeout.

--- a/pkg/services/email/smtp/smtp_dial.go
+++ b/pkg/services/email/smtp/smtp_dial.go
@@ -6,39 +6,46 @@ import (
 	"net"
 	"net/smtp"
 	"strconv"
+
+	"github.com/nicholas-fedor/shoutrrr/pkg/types"
 )
 
 // dialClient establishes a connection to the SMTP server using the provided configuration.
 //
-// Implicit TLS is used when [useImplicitTLS] reports that it is required; otherwise,
-// a plain TCP connection is opened. The context deadline is applied to the
-// connection when present.
+// A custom dial function is used when non-nil; otherwise a default [net.Dialer]
+// opens the TCP connection. Implicit TLS is applied after the TCP dial when
+// [useImplicitTLS] reports that it is required. The context deadline is applied
+// to the connection when present.
 //
 // Parameters:
 //   - ctx: Context that bounds dialing and the connection deadline.
 //   - config: SMTP configuration providing host, port, encryption, and TLS options.
+//   - dial: Optional custom TCP dial function. Nil uses [net.Dialer.DialContext].
 //
 // Returns:
 //   - An [smtp.Client] wrapping the established connection.
 //   - An error if dialing, applying the deadline, or creating the client fails.
-func dialClient(ctx context.Context, config *Config) (*smtp.Client, error) {
-	var (
-		conn net.Conn
-		err  error
-	)
-
+func dialClient(ctx context.Context, config *Config, dial types.DialContextFunc) (*smtp.Client, error) {
 	addr := net.JoinHostPort(config.Host, strconv.FormatUint(uint64(config.Port), 10))
 
-	if useImplicitTLS(config.Encryption, config.Port) {
-		dialer := &tls.Dialer{Config: newTLSConfig(config)}
-		conn, err = dialer.DialContext(ctx, "tcp", addr)
-	} else {
-		dialer := &net.Dialer{}
-		conn, err = dialer.DialContext(ctx, "tcp", addr)
+	if dial == nil {
+		dial = (&net.Dialer{}).DialContext
 	}
 
+	conn, err := dial(ctx, "tcp", addr)
 	if err != nil {
 		return nil, fail(FailConnectToServer, err)
+	}
+
+	if useImplicitTLS(config.Encryption, config.Port) {
+		tlsConn := tls.Client(conn, newTLSConfig(config))
+		if err := tlsConn.HandshakeContext(ctx); err != nil {
+			_ = conn.Close()
+
+			return nil, fail(FailConnectToServer, err)
+		}
+
+		conn = tlsConn
 	}
 
 	if deadline, ok := ctx.Deadline(); ok {

--- a/pkg/services/email/smtp/smtp_dial_test.go
+++ b/pkg/services/email/smtp/smtp_dial_test.go
@@ -2,11 +2,15 @@ package smtp
 
 import (
 	"context"
+	"errors"
 	"net"
+	"net/url"
 	"strconv"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 	gomega "github.com/onsi/gomega"
+
+	"github.com/nicholas-fedor/shoutrrr/pkg/types"
 )
 
 var _ = ginkgo.Describe("dialClient", func() {
@@ -19,7 +23,7 @@ var _ = ginkgo.Describe("dialClient", func() {
 			Port:        25,
 			FromAddress: "sender@example.com",
 			ToAddresses: []string{"rec@example.com"},
-		})
+		}, nil)
 		gomega.Expect(err).To(matchFailure(FailConnectToServer))
 		gomega.Expect(err).To(gomega.MatchError(context.Canceled))
 	})
@@ -28,7 +32,7 @@ var _ = ginkgo.Describe("dialClient", func() {
 		_, err := dialClient(context.Background(), &Config{
 			Host: "127.0.0.1",
 			Port: 1,
-		})
+		}, nil)
 		gomega.Expect(err).To(matchFailure(FailConnectToServer))
 	})
 
@@ -42,9 +46,79 @@ var _ = ginkgo.Describe("dialClient", func() {
 		port, err := strconv.ParseUint(portStr, 10, 16)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		client, err := dialClient(context.Background(), &Config{Host: host, Port: uint16(port)})
+		client, err := dialClient(context.Background(), &Config{Host: host, Port: uint16(port)}, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(client).NotTo(gomega.BeNil())
 		gomega.Expect(client.Close()).To(gomega.Succeed())
+	})
+
+	ginkgo.It("should use a custom dialer", func() {
+		address, _, stop := startGreetingServer()
+		defer stop()
+
+		host, portStr, err := net.SplitHostPort(address)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		port, err := strconv.ParseUint(portStr, 10, 16)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		var gotNetwork, gotAddr string
+
+		dial := func(ctx context.Context, network, addr string) (net.Conn, error) {
+			gotNetwork = network
+			gotAddr = addr
+
+			return (&net.Dialer{}).DialContext(ctx, network, addr)
+		}
+
+		client, err := dialClient(
+			context.Background(),
+			&Config{Host: host, Port: uint16(port)},
+			dial,
+		)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(client).NotTo(gomega.BeNil())
+		gomega.Expect(gotNetwork).To(gomega.Equal("tcp"))
+		gomega.Expect(gotAddr).To(gomega.Equal(net.JoinHostPort(host, portStr)))
+		gomega.Expect(client.Close()).To(gomega.Succeed())
+	})
+
+	ginkgo.It("should surface a custom dialer error as FailConnectToServer", func() {
+		blocked := errors.New("destination blocked")
+		_, err := dialClient(
+			context.Background(),
+			&Config{Host: "mail.example.com", Port: 587},
+			func(_ context.Context, _, _ string) (net.Conn, error) {
+				return nil, blocked
+			},
+		)
+		gomega.Expect(err).To(matchFailure(FailConnectToServer))
+		gomega.Expect(err).To(gomega.MatchError(blocked))
+	})
+})
+
+var _ = ginkgo.Describe("SetDialContext", func() {
+	ginkgo.It("should fail Send when the custom dialer blocks the destination", func() {
+		svc := &Service{}
+		serviceURL, err := url.Parse(
+			"smtp://mail.example.com:587/?fromaddress=from@example.com&toaddresses=to@example.com",
+		)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(svc.Initialize(serviceURL, logger)).To(gomega.Succeed())
+
+		blocked := errors.New("destination blocked")
+
+		svc.SetDialContext(func(_ context.Context, _, _ string) (net.Conn, error) {
+			return nil, blocked
+		})
+
+		err = svc.Send("hello", nil)
+		gomega.Expect(err).To(matchFailure(FailGetSMTPClient))
+		gomega.Expect(err).To(gomega.MatchError(blocked))
+	})
+
+	ginkgo.It("should satisfy DialContextSetter", func() {
+		var setter types.DialContextSetter = &Service{}
+		gomega.Expect(setter).NotTo(gomega.BeNil())
 	})
 })

--- a/pkg/services/email/smtp/smtp_helpers_test.go
+++ b/pkg/services/email/smtp/smtp_helpers_test.go
@@ -232,8 +232,7 @@ func asFailure(err error) failures.Failure {
 		return nil
 	}
 
-	var f failures.Failure
-	if errors.As(err, &f) {
+	if f, ok := errors.AsType[failures.Failure](err); ok {
 		return f
 	}
 

--- a/pkg/services/email/smtp/smtp_tls_test.go
+++ b/pkg/services/email/smtp/smtp_tls_test.go
@@ -33,6 +33,33 @@ var _ = ginkgo.Describe("TLS and live SMTP dialog", func() {
 		gomega.Expect(mock.dataString()).To(gomega.ContainSubstring("hello"))
 	})
 
+	ginkgo.It("should complete implicit TLS after a custom TCP dial", func() {
+		mock := newMockSMTP()
+		mock.implicitTLS = true
+
+		address, stop := startMockSMTP(mock)
+		defer stop()
+
+		serviceURL := testutils.URLMust(mockSMTPURL(address,
+			"encryption=ImplicitTLS&usestarttls=no&skiptlsverify=yes"))
+		gomega.Expect(service.Initialize(serviceURL, logger)).To(gomega.Succeed())
+
+		var gotNetwork, gotAddr string
+
+		service.SetDialContext(func(ctx context.Context, network, addr string) (net.Conn, error) {
+			gotNetwork = network
+			gotAddr = addr
+
+			return (&net.Dialer{}).DialContext(ctx, network, addr)
+		})
+
+		gomega.Expect(service.Send("hello", nil)).To(gomega.Succeed())
+		gomega.Expect(gotNetwork).To(gomega.Equal("tcp"))
+		gomega.Expect(gotAddr).To(gomega.Equal(address))
+		gomega.Eventually(mock.firstByte).Should(gomega.Receive(gomega.Equal(byte(0x16))))
+		gomega.Expect(mock.dataString()).To(gomega.ContainSubstring("hello"))
+	})
+
 	ginkgo.It("should reject implicit TLS with an untrusted certificate", func() {
 		mock := newMockSMTP()
 		mock.implicitTLS = true
@@ -133,7 +160,7 @@ var _ = ginkgo.Describe("TLS and live SMTP dialog", func() {
 		_, err = dialClient(context.Background(), &Config{
 			Host: host,
 			Port: uint16(port),
-		})
+		}, nil)
 		gomega.Expect(err).To(matchFailure(FailCreateSMTPClient))
 	})
 

--- a/pkg/services/push/bark/bark.go
+++ b/pkg/services/push/bark/bark.go
@@ -194,8 +194,7 @@ func (s *Service) sendAPI(config *Config, message string) error {
 
 	httpResp, err := s.HTTPClient.Do(httpReq)
 	if err != nil {
-		var jsonErr jsonclient.Error
-		if errors.As(err, &jsonErr) {
+		if jsonErr, ok := errors.AsType[jsonclient.Error](err); ok {
 			if json.Unmarshal([]byte(jsonErr.Body), &response) == nil {
 				return &response
 			}

--- a/pkg/services/push/mqtt/mqtt_errors.go
+++ b/pkg/services/push/mqtt/mqtt_errors.go
@@ -37,6 +37,9 @@ var (
 	// MQTT protocol only supports QoS levels 0, 1, and 2.
 	ErrInvalidQoS = errors.New("invalid QoS value: must be 0, 1, or 2")
 
+	// ErrNoDialContext is returned when a custom connection attempt runs without a dialer.
+	ErrNoDialContext = errors.New("custom dial context is not configured")
+
 	// ErrPasswordWithoutUsername is returned when a password is provided without a username.
 	// Password credentials require a username to be included in the URL.
 	ErrPasswordWithoutUsername = errors.New(

--- a/pkg/services/push/mqtt/mqtt_errors_test.go
+++ b/pkg/services/push/mqtt/mqtt_errors_test.go
@@ -140,6 +140,11 @@ var _ = ginkgo.Describe("MQTT Errors", func() {
 				To(gomega.Equal("MQTT connection manager not initialized"))
 		})
 
+		ginkgo.It("should match ErrNoDialContext", func() {
+			gomega.Expect(ErrNoDialContext.Error()).
+				To(gomega.Equal("custom dial context is not configured"))
+		})
+
 		ginkgo.It("should be usable with errors.Is for ErrPublishTimeout", func() {
 			err := ErrPublishTimeout
 			gomega.Expect(err).To(gomega.Equal(ErrPublishTimeout))

--- a/pkg/services/push/mqtt/mqtt_service.go
+++ b/pkg/services/push/mqtt/mqtt_service.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"net"
 	"net/url"
 	"sync"
 	"time"
 
 	"github.com/eclipse/paho.golang/autopaho"
+	"github.com/eclipse/paho.golang/packets"
 	"github.com/eclipse/paho.golang/paho"
 
 	"github.com/nicholas-fedor/shoutrrr/pkg/format"
@@ -28,6 +30,8 @@ type Service struct {
 	pkr format.PropKeyResolver
 	// connectionManager is the underlying MQTT connection manager for broker communication.
 	connectionManager ConnectionManager
+	// dialContext, if non-nil, is used for the MQTT TCP dial via AttemptConnection.
+	dialContext types.DialContextFunc
 	// clientMutex protects the connection initialization to ensure thread-safe
 	// lazy initialization while allowing retry on transient failures.
 	clientMutex sync.Mutex
@@ -70,6 +74,8 @@ const sessionExpiryInterval = 60
 // disconnectTimeout defines the maximum time in seconds to wait for graceful disconnection.
 // This prevents indefinite blocking when the broker is unresponsive during close operations.
 const disconnectTimeout = 5
+
+var _ types.DialContextSetter = (*Service)(nil)
 
 // Close gracefully shuts down the MQTT service by disconnecting from the broker
 // and canceling the connection context.
@@ -267,6 +273,63 @@ func (s *Service) SetConnectionManager(cm ConnectionManager) {
 	s.connectionInitialized = cm != nil
 }
 
+// SetDialContext sets a custom dial function for MQTT TCP connections.
+//
+// TLS wrapping for mqtts still happens after the TCP dial.
+// A nil dial restores the default autopaho dialer, including all_proxy handling.
+// This method should only be called before any Send operations to avoid
+// race conditions with lazy initialization.
+//
+// Parameters:
+//   - dial: The dial function. Must be safe for concurrent use when non-nil.
+func (s *Service) SetDialContext(dial types.DialContextFunc) {
+	s.dialContext = dial
+}
+
+// attemptConnection dials the MQTT broker using [Service.dialContext] and
+// optionally wraps the connection in TLS.
+//
+// Parameters:
+//   - ctx: Context that bounds dialing and the TLS handshake.
+//   - cfg: Autopaho client configuration providing TLS settings.
+//   - serverURL: Broker URL whose host and port are dialed.
+//
+// Returns:
+//   - A connected [net.Conn], TLS-wrapped and thread-safe when cfg.TlsCfg is set.
+//   - An error if the custom dialer is unset, dialing fails, or the handshake fails.
+func (s *Service) attemptConnection(
+	ctx context.Context,
+	cfg autopaho.ClientConfig, //nolint:gocritic // hugeParam: matches autopaho.AttemptConnection
+	serverURL *url.URL,
+) (net.Conn, error) {
+	if s.dialContext == nil {
+		return nil, ErrNoDialContext
+	}
+
+	conn, err := s.dialContext(ctx, "tcp", serverURL.Host)
+	if err != nil {
+		return nil, fmt.Errorf("dialing MQTT broker %q: %w", serverURL.Host, err)
+	}
+
+	if cfg.TlsCfg == nil {
+		return conn, nil
+	}
+
+	tlsCfg := cfg.TlsCfg.Clone()
+	if tlsCfg.ServerName == "" {
+		tlsCfg.ServerName = serverURL.Hostname()
+	}
+
+	tlsConn := tls.Client(conn, tlsCfg)
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
+		_ = conn.Close()
+
+		return nil, fmt.Errorf("TLS handshake with MQTT broker %q: %w", serverURL.Host, err)
+	}
+
+	return packets.NewThreadSafeConn(tlsConn), nil
+}
+
 // createTLSConfig builds a TLS configuration based on the service settings.
 // It enforces TLS 1.2 as the minimum version and optionally skips certificate
 // verification when DisableTLSVerification is set (useful for testing or
@@ -426,11 +489,10 @@ func (s *Service) initClient() error {
 		KeepAlive:                     keepAliveInterval,
 		CleanStartOnInitialConnection: s.Config.CleanSession,
 		SessionExpiryInterval:         sessionExpiryInterval,
-		ClientConfig: paho.ClientConfig{ //nolint:exhaustruct_v5 // remaining fields use library defaults
-			ClientID: s.Config.ClientID,
-			OnServerDisconnect: func(disconnect *paho.Disconnect) {
-				s.Logf("Server disconnected: reason code %d", disconnect.ReasonCode)
-			},
+		//nolint:exhaustruct_v5 // remaining fields use library defaults
+		ClientID: s.Config.ClientID,
+		OnServerDisconnect: func(disconnect *paho.Disconnect) {
+			s.Logf("Server disconnected: reason code %d", disconnect.ReasonCode)
 		},
 		OnConnectionUp: func(_ *autopaho.ConnectionManager, _ *paho.Connack) {
 			s.Logf("Connected to MQTT broker at %s", brokerURL)
@@ -456,6 +518,10 @@ func (s *Service) initClient() error {
 	// Configure TLS based on scheme and DisableTLS setting
 	if useTLS {
 		cliCfg.TlsCfg = s.createTLSConfig()
+	}
+
+	if s.dialContext != nil {
+		cliCfg.AttemptConnection = s.attemptConnection
 	}
 
 	// Create the connection manager

--- a/pkg/services/push/mqtt/mqtt_service.go
+++ b/pkg/services/push/mqtt/mqtt_service.go
@@ -295,7 +295,8 @@ func (s *Service) SetDialContext(dial types.DialContextFunc) {
 //   - serverURL: Broker URL whose host and port are dialed.
 //
 // Returns:
-//   - A connected [net.Conn], TLS-wrapped and thread-safe when cfg.TlsCfg is set.
+//   - A connected [net.Conn], TLS-wrapped when cfg.TlsCfg is set, always
+//     wrapped for thread-safe writes.
 //   - An error if the custom dialer is unset, dialing fails, or the handshake fails.
 func (s *Service) attemptConnection(
 	ctx context.Context,
@@ -312,7 +313,7 @@ func (s *Service) attemptConnection(
 	}
 
 	if cfg.TlsCfg == nil {
-		return conn, nil
+		return packets.NewThreadSafeConn(conn), nil
 	}
 
 	tlsCfg := cfg.TlsCfg.Clone()

--- a/pkg/services/push/mqtt/mqtt_test.go
+++ b/pkg/services/push/mqtt/mqtt_test.go
@@ -3,8 +3,12 @@ package mqtt
 import (
 	"context"
 	"crypto/tls"
+	"errors"
+	"net"
 	"net/url"
 	"sync"
+
+	"github.com/eclipse/paho.golang/autopaho"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 	gomega "github.com/onsi/gomega"
@@ -416,6 +420,130 @@ var _ = ginkgo.Describe("Service", func() {
 			gomega.Expect(svc.Config).NotTo(gomega.BeNil())
 			gomega.Expect(svc.connectionInitialized).To(gomega.BeFalse())
 			gomega.Expect(svc.connectionManager).To(gomega.BeNil())
+		})
+	})
+
+	ginkgo.Describe("SetDialContext", func() {
+		ginkgo.It("should satisfy DialContextSetter", func() {
+			var setter types.DialContextSetter = service
+			gomega.Expect(setter).NotTo(gomega.BeNil())
+		})
+
+		ginkgo.It("should store the custom dial function", func() {
+			dial := func(_ context.Context, _, _ string) (net.Conn, error) {
+				return nil, errors.New("unused")
+			}
+			service.SetDialContext(dial)
+			gomega.Expect(service.dialContext).NotTo(gomega.BeNil())
+		})
+	})
+
+	ginkgo.Describe("attemptConnection", func() {
+		ginkgo.It("should error when no custom dialer is configured", func() {
+			brokerURL, err := url.Parse("mqtt://broker.example.com:1883")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			_, err = service.attemptConnection(
+				context.Background(),
+				autopaho.ClientConfig{},
+				brokerURL,
+			)
+			gomega.Expect(err).To(gomega.MatchError(ErrNoDialContext))
+		})
+
+		ginkgo.It("should dial tcp at the broker host", func() {
+			blocked := errors.New("destination blocked")
+
+			var gotNetwork, gotAddr string
+
+			service.SetDialContext(func(_ context.Context, network, addr string) (net.Conn, error) {
+				gotNetwork = network
+				gotAddr = addr
+
+				return nil, blocked
+			})
+
+			brokerURL, err := url.Parse("mqtt://broker.example.com:1883")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			_, err = service.attemptConnection(
+				context.Background(),
+				autopaho.ClientConfig{},
+				brokerURL,
+			)
+			gomega.Expect(err).To(gomega.MatchError(blocked))
+			gomega.Expect(gotNetwork).To(gomega.Equal("tcp"))
+			gomega.Expect(gotAddr).To(gomega.Equal("broker.example.com:1883"))
+		})
+
+		ginkgo.It("should return a plain connection when TLS is not configured", func() {
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			defer listener.Close()
+
+			accepted := make(chan net.Conn, 1)
+
+			go func() {
+				conn, acceptErr := listener.Accept()
+				if acceptErr != nil {
+					return
+				}
+
+				accepted <- conn
+			}()
+
+			service.SetDialContext((&net.Dialer{}).DialContext)
+
+			brokerURL, err := url.Parse("mqtt://" + listener.Addr().String())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			conn, err := service.attemptConnection(
+				context.Background(),
+				autopaho.ClientConfig{},
+				brokerURL,
+			)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(conn).NotTo(gomega.BeNil())
+			gomega.Expect(conn.Close()).To(gomega.Succeed())
+
+			peer := <-accepted
+			gomega.Expect(peer.Close()).To(gomega.Succeed())
+		})
+
+		ginkgo.It("should fail the TLS handshake against a plaintext listener", func() {
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			defer listener.Close()
+
+			go func() {
+				conn, acceptErr := listener.Accept()
+				if acceptErr != nil {
+					return
+				}
+				defer conn.Close()
+
+				_, _ = conn.Read(make([]byte, 1))
+			}()
+
+			service.SetDialContext((&net.Dialer{}).DialContext)
+
+			brokerURL, err := url.Parse("mqtts://" + listener.Addr().String())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			_, err = service.attemptConnection(
+				context.Background(),
+				autopaho.ClientConfig{
+					TlsCfg: &tls.Config{
+						InsecureSkipVerify: true,
+						MinVersion:         tls.VersionTLS12,
+					},
+				},
+				brokerURL,
+			)
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("TLS handshake"))
 		})
 	})
 })

--- a/pkg/services/services_test.go
+++ b/pkg/services/services_test.go
@@ -1,7 +1,10 @@
 package services_test
 
 import (
+	"context"
+	"errors"
 	"log"
+	"net"
 	"net/http"
 	"testing"
 
@@ -166,6 +169,65 @@ var _ = ginkgo.Describe("services", func() {
 			sr, err := router.NewWithOptions(
 				logger,
 				types.SenderOptions{HTTPClient: customClient},
+				"generic+https://example.com/webhook",
+			)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			service, err := sr.Locate("generic+https://example.com/webhook")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			err = service.Send("test", nil)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+	})
+
+	ginkgo.Describe("custom DialContext injection", func() {
+		ginkgo.It("should use the injected dialer for SMTP", func() {
+			blocked := errors.New("destination blocked")
+
+			var gotNetwork, gotAddr string
+
+			dial := func(_ context.Context, network, addr string) (net.Conn, error) {
+				gotNetwork = network
+				gotAddr = addr
+
+				return nil, blocked
+			}
+
+			smtpURL := "smtp://mail.example.com:587/?fromAddress=from@host.tld&toAddresses=to@host.tld"
+			sr, err := router.NewWithOptions(
+				logger,
+				types.SenderOptions{DialContext: dial},
+				smtpURL,
+			)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			errs := sr.Send("test", nil)
+			gomega.Expect(errs).To(gomega.HaveLen(1))
+			gomega.Expect(errs[0]).To(gomega.MatchError(blocked))
+			gomega.Expect(gotNetwork).To(gomega.Equal("tcp"))
+			gomega.Expect(gotAddr).To(gomega.Equal("mail.example.com:587"))
+		})
+
+		ginkgo.It("should leave HTTP services unaffected", func() {
+			customClient := &http.Client{}
+			httpmock.ActivateNonDefault(customClient)
+			ginkgo.DeferCleanup(httpmock.DeactivateAndReset)
+
+			httpmock.RegisterResponder(
+				"POST",
+				"https://example.com/webhook",
+				httpmock.NewStringResponder(http.StatusOK, ""),
+			)
+
+			sr, err := router.NewWithOptions(
+				logger,
+				types.SenderOptions{
+					HTTPClient: customClient,
+					DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+						return nil, errors.New("should not dial")
+					},
+				},
 				"generic+https://example.com/webhook",
 			)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/pkg/types/dial.go
+++ b/pkg/types/dial.go
@@ -1,0 +1,20 @@
+package types
+
+import (
+	"context"
+	"net"
+)
+
+// DialContextFunc is the signature of [net.Dialer.DialContext] and
+// [http.Transport.DialContext].
+//
+// Implementations must be safe for concurrent use. A nil value means the
+// service should use its default dialer.
+type DialContextFunc func(ctx context.Context, network, addr string) (net.Conn, error)
+
+// DialContextSetter is implemented by services that accept a custom TCP dial
+// function for non-HTTP connections. This enables callers to control egress
+// and destination policy without global side effects.
+type DialContextSetter interface {
+	SetDialContext(dial DialContextFunc)
+}

--- a/pkg/types/doc.go
+++ b/pkg/types/doc.go
@@ -30,8 +30,12 @@
 //     Used for SSRF protection and custom egress control.
 //   - HTTPClientSetter: Implemented by services to accept a custom HTTPClient
 //     (injected by router.NewWithOptions / NewSenderWithOptions).
-//   - SenderOptions: Options for creating senders/routers, including HTTPClient
-//     and Timeout overrides.
+//   - DialContextFunc: Signature of net.Dialer.DialContext for non-HTTP TCP
+//     connections. Used for SSRF protection and custom egress control.
+//   - DialContextSetter: Implemented by services to accept a custom DialContextFunc
+//     (injected by router.NewWithOptions / NewSenderWithOptions).
+//   - SenderOptions: Options for creating senders/routers, including HTTPClient,
+//     DialContext, and Timeout overrides.
 //
 // # Message Types
 //

--- a/pkg/types/sender_options.go
+++ b/pkg/types/sender_options.go
@@ -8,11 +8,20 @@ import "time"
 // made by the resulting sender/router. This allows callers to supply
 // custom transports, dialers, TLS configuration, timeouts, etc.
 //
+// DialContext, if non-nil, will be used for outbound TCP connections
+// made by services that implement [DialContextSetter]. Implementations
+// must be safe for concurrent use. TLS wrapping remains the service's
+// responsibility after the TCP dial. A nil value uses the service default.
+//
 // Timeout, if > 0, overrides the default per-service timeout.
 type SenderOptions struct {
 	// HTTPClient is the client used for all HTTP operations.
 	// If nil, a default client with reasonable settings is used.
 	HTTPClient HTTPClient
+
+	// DialContext is the dial function used for non-HTTP TCP connections.
+	// If nil, services use their default dialer.
+	DialContext DialContextFunc
 
 	// Timeout overrides the default operation timeout when > 0.
 	Timeout time.Duration

--- a/pkg/util/jsonclient/jsonclient.go
+++ b/pkg/util/jsonclient/jsonclient.go
@@ -67,8 +67,7 @@ func (je Error) String() string {
 
 // ErrorBody extracts the request body from an error if it's a jsonclient.Error.
 func ErrorBody(e error) string {
-	var jsonError Error
-	if errors.As(e, &jsonError) {
+	if jsonError, ok := errors.AsType[Error](e); ok {
 		return jsonError.Body
 	}
 
@@ -117,8 +116,7 @@ func Post(url string, request, response any) error {
 
 // ErrorResponse checks if an error is a JSON error and unmarshals its body into the response.
 func (c *client) ErrorResponse(err error, response any) bool {
-	var errMsg Error
-	if errors.As(err, &errMsg) {
+	if errMsg, ok := errors.AsType[Error](err); ok {
 		return json.Unmarshal([]byte(errMsg.Body), response) == nil
 	}
 

--- a/shoutrrr.go
+++ b/shoutrrr.go
@@ -81,8 +81,9 @@ func NewSender(logger types.StdLogger, serviceURLs ...string) (*router.ServiceRo
 }
 
 // NewSenderWithOptions constructs a new service router using the given logger,
-// SenderOptions, and URLs. Use this to supply a custom HTTPClient for all
-// outbound requests (e.g. for SSRF protection or custom proxies/TLS).
+// SenderOptions, and URLs. Use this to supply a custom HTTPClient for HTTP
+// services and DialContext for TCP services (e.g. for SSRF protection or
+// custom proxies/TLS).
 func NewSenderWithOptions(logger types.StdLogger, opts types.SenderOptions, serviceURLs ...string) (*router.ServiceRouter, error) {
 	serviceRouter, err := router.NewWithOptions(logger, opts, serviceURLs...)
 	if err != nil {

--- a/shoutrrr/cmd/send/send_test.go
+++ b/shoutrrr/cmd/send/send_test.go
@@ -487,8 +487,7 @@ func Test_run(t *testing.T) {
 				}
 
 				if tt.wantErrType != "" {
-					var exitErr cli.ExitError
-					if errors.As(runErr, &exitErr) {
+					if exitErr, ok := errors.AsType[cli.ExitError](runErr); ok {
 						switch tt.wantErrType {
 						case "ConfigurationError":
 							assert.Equal(t, cli.ExConfig, exitErr.ExitCode, "Exit code should be ExConfig")

--- a/shoutrrr/cmd/verify/verify_test.go
+++ b/shoutrrr/cmd/verify/verify_test.go
@@ -42,8 +42,7 @@ func TestRun_FlagRetrievalError(t *testing.T) {
 
 	err := cmd.Run()
 
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
+	if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 		assert.Equal(t, 1, exitErr.ExitCode(), "Exit code mismatch")
 	} else {
 		t.Fatalf("Expected ExitError, got: %v", err)
@@ -79,8 +78,7 @@ func TestRun_UnknownService(t *testing.T) {
 	err := cmd.Run()
 	output := outputBuf.String()
 
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
+	if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 		assert.Equal(t, 1, exitErr.ExitCode(), "Exit code mismatch")
 	} else {
 		t.Fatalf("Expected ExitError, got: %v", err)
@@ -113,8 +111,7 @@ func TestRun_InvalidURLFormat(t *testing.T) {
 
 	err := cmd.Run()
 
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
+	if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 		assert.Equal(t, 1, exitErr.ExitCode(), "Exit code mismatch")
 	} else {
 		t.Fatalf("Expected ExitError, got: %v", err)
@@ -153,8 +150,7 @@ func TestRun_SubprocessErrorOutput(t *testing.T) {
 	output := outputBuf.String()
 
 	// Should exit with code 1
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
+	if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 		assert.Equal(t, 1, exitErr.ExitCode(), "Should exit with code 1")
 	} else {
 		t.Fatalf("Expected ExitError, got: %v", err)
@@ -305,8 +301,7 @@ func TestRun_IntegrationWithExitCodes_InvalidURL(t *testing.T) {
 
 	err := cmd.Run()
 
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
+	if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 		assert.Equal(t, 1, exitErr.ExitCode(), "Exit code mismatch")
 	} else {
 		t.Fatalf("Expected ExitError with code 1, got: %v", err)
@@ -405,8 +400,7 @@ func TestRun_StderrOutput(t *testing.T) {
 	err := cmd.Run()
 
 	// Should fail
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
+	if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 		assert.Equal(t, 1, exitErr.ExitCode(), "Should exit with code 1")
 	} else {
 		t.Fatalf("Expected ExitError, got: %v", err)
@@ -529,8 +523,7 @@ func TestRun_WithUnknownSchemeFails(t *testing.T) {
 
 	err := cmd.Run()
 
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
+	if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 		assert.Equal(t, 1, exitErr.ExitCode(), "Expected exit code 1 for invalid scheme")
 	} else {
 		t.Fatalf("Expected ExitError, got: %v", err)
@@ -566,8 +559,7 @@ func TestRun_MultipleURLs(t *testing.T) {
 	err := cmd.Run()
 	output := outputBuf.String()
 
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
+	if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 		assert.Equal(t, 1, exitErr.ExitCode(), "Expected exit code 1 for multiple URLs")
 	} else {
 		t.Fatalf("Expected ExitError, got: %v", err)


### PR DESCRIPTION
This PR adds `DialContext` injection so SMTP and MQTT notifications can apply destination policy at connect time.

## Problem

When Shoutrrr would send an SMTP or MQTT notification, callers could not intercept the TCP dial. HTTP services already honored `SenderOptions.HTTPClient`, so destination policy could be applied there, but SMTP and MQTT would still connect with the default dialer.

This was because `SenderOptions` had no equivalent hook for non-HTTP TCP connections.

## Solution

Added `DialContext` to `SenderOptions` so callers can apply the same destination policy they already use for HTTP. SMTP and MQTT now dial through that function when it is set.

TLS wrapping for implicit SMTP TLS and mqtts remains Shoutrrr's responsibility after the TCP connect. `shoutrrr.Send` still has no options path; callers use `NewSenderWithOptions`.

## Changes

- Add `SenderOptions.DialContext` and `DialContextSetter`
- Honor the dialer in SMTP and MQTT
- Document DialContext for per-sender SSRF and egress control